### PR TITLE
Typed value

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -20,6 +20,7 @@ module Css
         , Cm
         , Color
         , ColorStop
+        , ColorValue
         , Compatible
         , Cursor
         , Directionality
@@ -59,7 +60,6 @@ module Css
         , ListStyleType
         , MinMaxDimension
         , Mm
-        , NonMixable
         , None
         , Number
         , Outline
@@ -1020,7 +1020,7 @@ functions let you define custom properties and selectors, respectively.
 @docs listStyle, listStyle2, listStyle3
 @docs linearGradient, linearGradient2, stop, stop2, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
-@docs AlignItems, All, Angle, AngleOrDirection, BackgroundAttachment, BackgroundClip, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatShorthand, BasicProperty, BorderCollapse, BorderStyle, BoxSizing, Calc, CalcExpression, Cursor, Directionality, Display, ExplicitLength, FeatureTagValue, FlexBasis, FlexDirection, FlexDirectionOrWrap, FlexWrap, FontFamily, FontStyle, FontStyleOrFeatureTagValue, FontVariant, FontVariantCaps, FontVariantLigatures, FontVariantNumeric, FontWeight, ImportType, IncompatibleUnits, JustifyContent, LengthOrAuto, LengthOrAutoOrCoverOrContain, LengthOrMinMaxDimension, LengthOrNone, LengthOrNoneOrMinMaxDimension, LengthOrNumber, LengthOrNumberOrAutoOrNoneOrContent, ListStyle, ListStylePosition, ListStyleType, MinMaxDimension, NonMixable, None, Number, Outline, Overflow, Visibility, Position, Resize, TableLayout, TextDecorationLine, TextDecorationStyle, TextIndent, TextOrientation, TextOverflow, TextRendering, TextTransform, TouchAction, Transform, TransformBox, TransformStyle, Value, VerticalAlign, WhiteSpace, Wrap, pre, preLine, preWrap
+@docs AlignItems, All, Angle, AngleOrDirection, BackgroundAttachment, BackgroundClip, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatShorthand, BasicProperty, BorderCollapse, BorderStyle, BoxSizing, Calc, CalcExpression, Cursor, Directionality, Display, ExplicitLength, FeatureTagValue, FlexBasis, FlexDirection, FlexDirectionOrWrap, FlexWrap, FontFamily, FontStyle, FontStyleOrFeatureTagValue, FontVariant, FontVariantCaps, FontVariantLigatures, FontVariantNumeric, FontWeight, ImportType, IncompatibleUnits, JustifyContent, LengthOrAuto, LengthOrAutoOrCoverOrContain, LengthOrMinMaxDimension, LengthOrNone, LengthOrNoneOrMinMaxDimension, LengthOrNumber, LengthOrNumberOrAutoOrNoneOrContent, ListStyle, ListStylePosition, ListStyleType, MinMaxDimension, None, Number, Outline, Overflow, Visibility, Position, Resize, TableLayout, TextDecorationLine, TextDecorationStyle, TextIndent, TextOrientation, TextOverflow, TextRendering, TextTransform, TouchAction, Transform, TransformBox, TransformStyle, Value, VerticalAlign, WhiteSpace, Wrap, pre, preLine, preWrap
 
 
 # Types
@@ -1436,17 +1436,6 @@ type alias BackgroundPosition compatible =
     Value { compatible | backgroundPosition : Compatible }
 
 
-{-| Because `color` is both a common propertie and common value
-in CSS (e.g. `color: red` with and `background-blend-mode: color`),
-we implement it as a property (for the `color: red` case) and allow it to
-be used as a value as well. When being used as a value, we call it, expect
-that it will return the desired String as its key, and use that as our value.
-(See `getOverloadedProperty`. Note that `VerticalAlign`.)
--}
-type alias BackgroundBlendMode compatible =
-    ColorValue compatible -> Style
-
-
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip>
 -}
 type alias BackgroundClip compatible =
@@ -1595,26 +1584,6 @@ minus =
     Subtraction
 
 
-combineLengths :
-    (number -> number -> number)
-    -> { r | numericValue : number, unitLabel : String, value : String }
-    -> { r | numericValue : number, unitLabel : String, value : String }
-    -> { r | numericValue : number, unitLabel : String, value : String }
-combineLengths operation first second =
-    let
-        numericValue =
-            operation first.numericValue second.numericValue
-
-        value =
-            [ toString numericValue
-            , first.unitLabel
-            ]
-                |> List.filter (not << String.isEmpty)
-                |> String.join ""
-    in
-    { first | value = value, numericValue = numericValue }
-
-
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrAuto compatible =
@@ -1648,9 +1617,7 @@ type alias LengthOrNumber compatible =
 {-| -}
 type alias ExplicitLength units =
     Value
-        { numericValue : Float
-        , units : units
-        , unitLabel : String
+        { units : units
         , length : Compatible
         , lengthOrAuto : Compatible
         , lengthOrNumber : Compatible
@@ -1824,13 +1791,6 @@ makeImportant str =
         str ++ " !important"
 
 
-{-| A [`ColorValue`](#ColorValue) that does not have `red`, `green`, or `blue`
-values.
--}
-type alias NonMixable =
-    {}
-
-
 {-| A [`transparent`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#transparent_keyword) color.
 -}
 transparent : Color
@@ -1907,98 +1867,98 @@ vertical =
 
 {-| The `multiply` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#multiply).
 -}
-multiply : BackgroundBlendMode compatible
+multiply : ColorValue compatible -> Style
 multiply =
     prop1 "multiply"
 
 
 {-| The `screen` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#screen).
 -}
-screenBlendMode : BackgroundBlendMode compatible
+screenBlendMode : ColorValue compatible -> Style
 screenBlendMode =
     prop1 "screen"
 
 
 {-| The `overlay` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#overlay).
 -}
-overlay : BackgroundBlendMode compatible
+overlay : ColorValue compatible -> Style
 overlay =
     prop1 "overlay"
 
 
 {-| The `darken` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#darken).
 -}
-darken : BackgroundBlendMode compatible
+darken : ColorValue compatible -> Style
 darken =
     prop1 "darken"
 
 
 {-| The `lighten` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#lighten).
 -}
-lighten : BackgroundBlendMode compatible
+lighten : ColorValue compatible -> Style
 lighten =
     prop1 "lighten"
 
 
 {-| The `color-dodge` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#color-dodge).
 -}
-colorDodge : BackgroundBlendMode compatible
+colorDodge : ColorValue compatible -> Style
 colorDodge =
     prop1 "color-dodge"
 
 
 {-| The `color-burn` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#color-burn).
 -}
-colorBurn : BackgroundBlendMode compatible
+colorBurn : ColorValue compatible -> Style
 colorBurn =
     prop1 "color-burn"
 
 
 {-| The `hard-light` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#hard-light).
 -}
-hardLight : BackgroundBlendMode compatible
+hardLight : ColorValue compatible -> Style
 hardLight =
     prop1 "hard-light"
 
 
 {-| The `soft-light` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#soft-light).
 -}
-softLight : BackgroundBlendMode compatible
+softLight : ColorValue compatible -> Style
 softLight =
     prop1 "soft-light"
 
 
 {-| The `difference` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#difference).
 -}
-difference : BackgroundBlendMode compatible
+difference : ColorValue compatible -> Style
 difference =
     prop1 "difference"
 
 
 {-| The `exclusion` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#exclusion).
 -}
-exclusion : BackgroundBlendMode compatible
+exclusion : ColorValue compatible -> Style
 exclusion =
     prop1 "exclusion"
 
 
 {-| The `hue` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#hue).
 -}
-hue : BackgroundBlendMode compatible
+hue : ColorValue compatible -> Style
 hue =
     prop1 "hue"
 
 
 {-| The `saturation` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#saturation).
 -}
-saturation : BackgroundBlendMode compatible
+saturation : ColorValue compatible -> Style
 saturation =
     prop1 "saturation"
 
 
 {-| The `luminosity` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#luminosity).
 -}
-luminosity : BackgroundBlendMode compatible
+luminosity : ColorValue compatible -> Style
 luminosity =
     prop1 "luminosity"
 
@@ -2460,26 +2420,9 @@ true =
 {- LENGTHS -}
 
 
-lengthConverter : units -> String -> Float -> ExplicitLength units
-lengthConverter units unitLabel numericValue =
-    { value = numberToString numericValue ++ unitLabel
-    , numericValue = numericValue
-    , units = units
-    , unitLabel = unitLabel
-    , length = Compatible
-    , lengthOrAuto = Compatible
-    , lengthOrNumber = Compatible
-    , lengthOrNone = Compatible
-    , lengthOrMinMaxDimension = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    , textIndent = Compatible
-    , flexBasis = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , fontSize = Compatible
-    , absoluteLength = Compatible
-    , lengthOrAutoOrCoverOrContain = Compatible
-    , calc = Compatible
-    }
+lengthConverter : String -> Float -> ExplicitLength units
+lengthConverter label value =
+    Value (numberToString value ++ label)
 
 
 {-| Convenience length value that compiles to 0 with no units.
@@ -2520,7 +2463,7 @@ type alias Pct =
 -}
 pct : Float -> Pct
 pct =
-    lengthConverter PercentageUnits "%"
+    lengthConverter "%"
 
 
 type PercentageUnits
@@ -2537,7 +2480,7 @@ type alias Em =
 -}
 em : Float -> Em
 em =
-    lengthConverter EmUnits "em"
+    lengthConverter "em"
 
 
 type EmUnits
@@ -2554,7 +2497,7 @@ type alias Ex =
 -}
 ex : Float -> Ex
 ex =
-    lengthConverter ExUnits "ex"
+    lengthConverter "ex"
 
 
 type ExUnits
@@ -2571,7 +2514,7 @@ type alias Ch =
 -}
 ch : Float -> Ch
 ch =
-    lengthConverter ChUnits "ch"
+    lengthConverter "ch"
 
 
 type ChUnits
@@ -2588,7 +2531,7 @@ type alias Rem =
 -}
 rem : Float -> Rem
 rem =
-    lengthConverter RemUnits "rem"
+    lengthConverter "rem"
 
 
 type RemUnits
@@ -2605,7 +2548,7 @@ type alias Vh =
 -}
 vh : Float -> Vh
 vh =
-    lengthConverter VhUnits "vh"
+    lengthConverter "vh"
 
 
 type VhUnits
@@ -2622,7 +2565,7 @@ type alias Vw =
 -}
 vw : Float -> Vw
 vw =
-    lengthConverter VwUnits "vw"
+    lengthConverter "vw"
 
 
 type VwUnits
@@ -2639,7 +2582,7 @@ type alias Vmin =
 -}
 vmin : Float -> Vmin
 vmin =
-    lengthConverter VMinUnits "vmin"
+    lengthConverter "vmin"
 
 
 type VMinUnits
@@ -2656,7 +2599,7 @@ type alias Vmax =
 -}
 vmax : Float -> Vmax
 vmax =
-    lengthConverter VMaxUnits "vmax"
+    lengthConverter "vmax"
 
 
 type VMaxUnits
@@ -2673,7 +2616,7 @@ type alias Px =
 -}
 px : Float -> Px
 px =
-    lengthConverter PxUnits "px"
+    lengthConverter "px"
 
 
 type PxUnits
@@ -2690,7 +2633,7 @@ type alias Mm =
 -}
 mm : Float -> Mm
 mm =
-    lengthConverter MMUnits "mm"
+    lengthConverter "mm"
 
 
 type MMUnits
@@ -2707,7 +2650,7 @@ type alias Cm =
 -}
 cm : Float -> Cm
 cm =
-    lengthConverter CMUnits "cm"
+    lengthConverter "cm"
 
 
 type CMUnits
@@ -2727,7 +2670,7 @@ type alias In =
 -}
 inches : Float -> In
 inches =
-    lengthConverter InchUnits "in"
+    lengthConverter "in"
 
 
 type InchUnits
@@ -2744,7 +2687,7 @@ type alias Pt =
 -}
 pt : Float -> Pt
 pt =
-    lengthConverter PtUnits "pt"
+    lengthConverter "pt"
 
 
 type PtUnits
@@ -2761,7 +2704,7 @@ type alias Pc =
 -}
 pc : Float -> Pc
 pc =
-    lengthConverter PcUnits "pc"
+    lengthConverter "pc"
 
 
 type PcUnits
@@ -2794,7 +2737,7 @@ type UnitlessFloat
 
 lengthForOverloadedProperty : ExplicitLength IncompatibleUnits
 lengthForOverloadedProperty =
-    lengthConverter IncompatibleUnits "" 0
+    lengthConverter "" 0
 
 
 {-| -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1128,33 +1128,33 @@ type alias Compatible =
 
 
 {-| -}
-type alias Value compatible =
-    { compatible | value : String }
+type Value compatible
+    = Value String
 
 
 {-| -}
 type alias All compatible =
-    { compatible | value : String, all : Compatible }
+    Value { compatible | all : Compatible }
 
 
 {-| -}
 type alias Number compatible =
-    { compatible | value : String, number : Compatible }
+    Value { compatible | number : Compatible }
 
 
 {-| -}
 type alias None compatible =
-    { compatible | value : String, none : Compatible }
+    Value { compatible | none : Compatible }
 
 
 {-| -}
 type alias MinMaxDimension compatible =
-    { compatible
-        | value : String
-        , minMaxDimension : Compatible
-        , lengthOrMinMaxDimension : Compatible
-        , lengthOrNoneOrMinMaxDimension : Compatible
-    }
+    Value
+        { compatible
+            | minMaxDimension : Compatible
+            , lengthOrMinMaxDimension : Compatible
+            , lengthOrNoneOrMinMaxDimension : Compatible
+        }
 
 
 
@@ -1163,141 +1163,141 @@ type alias MinMaxDimension compatible =
 
 {-| -}
 type alias ImportType compatible =
-    { compatible | value : String, import_ : Compatible }
+    Value { compatible | import_ : Compatible }
 
 
 type alias FontFace compatible =
-    { compatible | value : String, fontFace : Compatible }
+    Value { compatible | fontFace : Compatible }
 
 
 {-| A font family
 -}
 type alias FontFamily compatible =
-    { compatible | value : String, fontFamily : Compatible }
+    Value { compatible | fontFamily : Compatible }
 
 
 {-| A font size
 -}
 type alias FontSize compatible =
-    { compatible | value : String, fontSize : Compatible }
+    Value { compatible | fontSize : Compatible }
 
 
 {-| -}
 type alias FontStyle compatible =
-    { compatible | value : String, fontStyle : Compatible }
+    Value { compatible | fontStyle : Compatible }
 
 
 {-| -}
 type alias FontStyleOrFeatureTagValue compatible =
-    { compatible | value : String, fontStyle : Compatible, featureTagValue : Compatible }
+    Value { compatible | fontStyle : Compatible, featureTagValue : Compatible }
 
 
 {-| -}
 type alias FontWeight compatible =
-    { compatible | value : String, fontWeight : Compatible }
+    Value { compatible | fontWeight : Compatible }
 
 
 {-| -}
 type alias FontVariant compatible =
-    { compatible | value : String, fontVariant : Compatible }
+    Value { compatible | fontVariant : Compatible }
 
 
 {-| -}
 type alias FontVariantLigatures compatible =
-    { compatible
-        | value : String
-        , fontVariant : Compatible
-        , fontVariantLigatures : Compatible
-    }
+    Value
+        { compatible
+            | fontVariant : Compatible
+            , fontVariantLigatures : Compatible
+        }
 
 
 {-| -}
 type alias FontVariantCaps compatible =
-    { compatible
-        | value : String
-        , fontVariant : Compatible
-        , fontVariantCaps : Compatible
-    }
+    Value
+        { compatible
+            | fontVariant : Compatible
+            , fontVariantCaps : Compatible
+        }
 
 
 {-| -}
 type alias FontVariantNumeric compatible =
-    { compatible
-        | value : String
-        , fontVariant : Compatible
-        , fontVariantNumeric : Compatible
-    }
+    Value
+        { compatible
+            | fontVariant : Compatible
+            , fontVariantNumeric : Compatible
+        }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#Values>
 -}
 type alias Visibility compatible =
-    { compatible | value : String, visibility : Compatible }
+    Value { compatible | visibility : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Values>
 -}
 type alias TextDecorationLine compatible =
-    { compatible | value : String, textDecorationLine : Compatible }
+    Value { compatible | textDecorationLine : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing#Values>
 -}
 type alias BoxSizing compatible =
-    { compatible | value : String, boxSizing : Compatible }
+    Value { compatible | boxSizing : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values>
 -}
 type alias Overflow compatible =
-    { compatible | value : String, overflow : Compatible }
+    Value { compatible | overflow : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#Values>
 -}
 type alias Wrap compatible =
-    { compatible | value : String, overflowWrap : Compatible }
+    Value { compatible | overflowWrap : Compatible }
 
 
 {-| <https://developer.mozilla.org/en/docs/Web/CSS/resize#Values>
 -}
 type alias Resize compatible =
-    { compatible | value : String, resize : Compatible }
+    Value { compatible | resize : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/flex#Values>
 -}
 type alias LengthOrNumberOrAutoOrNoneOrContent compatible =
-    { compatible | value : String, lengthOrNumberOrAutoOrNoneOrContent : Compatible }
+    Value { compatible | lengthOrNumberOrAutoOrNoneOrContent : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/z-index>
 -}
 type alias IntOrAuto compatible =
-    { compatible | value : String, intOrAuto : Compatible }
+    Value { compatible | intOrAuto : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values>
 -}
 type alias FlexBasis compatible =
-    { compatible | value : String, flexBasis : Compatible }
+    Value { compatible | flexBasis : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values>
 -}
 type alias FlexWrap compatible =
-    { compatible | value : String, flexWrap : Compatible }
+    Value { compatible | flexWrap : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values>
 -}
 type alias FlexDirection compatible =
-    { compatible | value : String, flexDirection : Compatible }
+    Value { compatible | flexDirection : Compatible }
 
 
 {-| -}
 type alias FlexDirectionOrWrap compatible =
-    { compatible | value : String, flexDirectionOrWrap : Compatible }
+    Value { compatible | flexDirectionOrWrap : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#Values>
@@ -1321,43 +1321,43 @@ type alias JustifyContent a b =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values>
 -}
 type alias Display compatible =
-    { compatible | value : String, display : Compatible }
+    Value { compatible | display : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events#Values>
 -}
 type alias PointerEvents compatible =
-    { compatible | value : String, pointerEvents : Compatible }
+    Value { compatible | pointerEvents : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Values>
 -}
 type alias ListStyleType compatible =
-    { compatible | value : String, listStyleType : Compatible }
+    Value { compatible | listStyleType : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position#Values>
 -}
 type alias ListStylePosition compatible =
-    { compatible | value : String, listStylePosition : Compatible }
+    Value { compatible | listStylePosition : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#Values>
 -}
 type alias ListStyle compatible =
-    { compatible | value : String, listStyleTypeOrPositionOrImage : Compatible }
+    Value { compatible | listStyleTypeOrPositionOrImage : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#Values>
 -}
 type alias WhiteSpace compatible =
-    { compatible | value : String, whiteSpace : Compatible }
+    Value { compatible | whiteSpace : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/color#Values>
 -}
 type alias ColorValue compatible =
-    { compatible | value : String, color : Compatible }
+    Value { compatible | color : Compatible }
 
 
 colorValueForOverloadedProperty : ColorValue NonMixable
@@ -1366,31 +1366,31 @@ colorValueForOverloadedProperty =
 
 
 {-| -}
-type alias Color =
-    ColorValue { red : Int, green : Int, blue : Int, alpha : Float }
+type Color
+    = Color Int Int Int Float
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#repeat-style>
 -}
 type alias BackgroundRepeat compatible =
-    { compatible | value : String, backgroundRepeat : Compatible, backgroundRepeatShorthand : Compatible }
+    Value { compatible | backgroundRepeat : Compatible, backgroundRepeatShorthand : Compatible }
 
 
 {-| -}
 type alias BackgroundRepeatShorthand compatible =
-    { compatible | value : String, backgroundRepeatShorthand : Compatible }
+    Value { compatible | backgroundRepeatShorthand : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment>
 -}
 type alias BackgroundAttachment compatible =
-    { compatible | value : String, backgroundAttachment : Compatible }
+    Value { compatible | backgroundAttachment : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-position>
 -}
 type alias BackgroundPosition compatible =
-    { compatible | value : String, backgroundPosition : Compatible }
+    Value { compatible | backgroundPosition : Compatible }
 
 
 {-| Because `color` is both a common propertie and common value
@@ -1407,7 +1407,7 @@ type alias BackgroundBlendMode a =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip>
 -}
 type alias BackgroundClip compatible =
-    { compatible | value : String, backgroundClip : Compatible }
+    Value { compatible | backgroundClip : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin>
@@ -1419,51 +1419,48 @@ type alias BackgroundOrigin compatible =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-image>
 -}
 type alias BackgroundImage compatible =
-    { compatible | value : String, backgroundImage : Compatible }
+    Value { compatible | backgroundImage : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-size>
 -}
 type alias LengthOrAutoOrCoverOrContain compatible =
-    { compatible | value : String, lengthOrAutoOrCoverOrContain : Compatible }
+    Value { compatible | lengthOrAutoOrCoverOrContain : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias Length compatible units =
-    { compatible
-        | value : String
-        , length : Compatible
-        , numericValue : Float
-        , units : units
-        , unitLabel : String
-    }
+    Value
+        { compatible
+            | length : Compatible
+            , numericValue : Float
+            , units : units
+            , unitLabel : String
+        }
 
 
 {-| <https://developer.mozilla.org/en/docs/Web/CSS/calc>
 -}
 type alias Calc compatible =
-    { compatible
-        | value : String
-        , calc : Compatible
-    }
+    Value { compatible | calc : Compatible }
 
 
 type alias CalculatedLength =
-    { value : String
-    , length : Compatible
-    , lengthOrAuto : Compatible
-    , lengthOrNumber : Compatible
-    , lengthOrNone : Compatible
-    , lengthOrMinMaxDimension : Compatible
-    , lengthOrNoneOrMinMaxDimension : Compatible
-    , textIndent : Compatible
-    , flexBasis : Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
-    , fontSize : Compatible
-    , lengthOrAutoOrCoverOrContain : Compatible
-    , calc : Compatible
-    }
+    Value
+        { length : Compatible
+        , lengthOrAuto : Compatible
+        , lengthOrNumber : Compatible
+        , lengthOrNone : Compatible
+        , lengthOrMinMaxDimension : Compatible
+        , lengthOrNoneOrMinMaxDimension : Compatible
+        , textIndent : Compatible
+        , flexBasis : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , fontSize : Compatible
+        , lengthOrAutoOrCoverOrContain : Compatible
+        , calc : Compatible
+        }
 
 
 {-| -}
@@ -1485,13 +1482,13 @@ calcExpressionToString expression =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action?v=control#Values>
 -}
 type alias TouchAction compatible =
-    { compatible | value : String, touchAction : Compatible }
+    Value { compatible | touchAction : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout?v=control#Values>
 -}
 type alias TableLayout compatible =
-    { compatible | value : String, tableLayout : Compatible }
+    Value { compatible | tableLayout : Compatible }
 
 
 {-| The css [calc](https://developer.mozilla.org/en/docs/Web/CSS/calc) function.
@@ -1515,13 +1512,13 @@ Using * and / with calc isn't supported. Use arithmetics from elm instead.
 
 -}
 calc : Calc compatibleA -> CalcExpression -> Calc compatibleB -> CalculatedLength
-calc first expression second =
+calc (Value first) expression (Value second) =
     let
         grab l =
-            if String.startsWith "calc(" l.value then
-                String.dropLeft 4 l.value
+            if String.startsWith "calc(" l then
+                String.dropLeft 4 l
             else
-                l.value
+                l
 
         calcs =
             String.join " "
@@ -1529,24 +1526,8 @@ calc first expression second =
                 , calcExpressionToString expression
                 , grab second
                 ]
-
-        value =
-            cssFunction "calc" [ calcs ]
     in
-    { value = value
-    , length = Compatible
-    , lengthOrAuto = Compatible
-    , lengthOrNumber = Compatible
-    , lengthOrNone = Compatible
-    , lengthOrMinMaxDimension = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    , textIndent = Compatible
-    , flexBasis = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , fontSize = Compatible
-    , lengthOrAutoOrCoverOrContain = Compatible
-    , calc = Compatible
-    }
+    Value (cssFunction "calc" [ calcs ])
 
 
 {-| Use with calc to add lengths together
@@ -1594,149 +1575,149 @@ combineLengths operation first second =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrAuto compatible =
-    { compatible | value : String, lengthOrAuto : Compatible }
+    Value { compatible | lengthOrAuto : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrNoneOrMinMaxDimension compatible =
-    { compatible | value : String, lengthOrNoneOrMinMaxDimension : Compatible }
+    Value { compatible | lengthOrNoneOrMinMaxDimension : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrMinMaxDimension compatible =
-    { compatible | value : String, lengthOrMinMaxDimension : Compatible }
+    Value { compatible | lengthOrMinMaxDimension : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrNone compatible =
-    { compatible | value : String, lengthOrNone : Compatible }
+    Value { compatible | lengthOrNone : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias LengthOrNumber compatible =
-    { compatible | value : String, lengthOrNumber : Compatible }
+    Value { compatible | lengthOrNumber : Compatible }
 
 
 {-| -}
 type alias ExplicitLength units =
-    { value : String
-    , numericValue : Float
-    , units : units
-    , unitLabel : String
-    , length : Compatible
-    , lengthOrAuto : Compatible
-    , lengthOrNumber : Compatible
-    , lengthOrNone : Compatible
-    , lengthOrMinMaxDimension : Compatible
-    , lengthOrNoneOrMinMaxDimension : Compatible
-    , textIndent : Compatible
-    , flexBasis : Compatible
-    , absoluteLength : Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
-    , fontSize : Compatible
-    , lengthOrAutoOrCoverOrContain : Compatible
-    , calc : Compatible
-    }
+    Value
+        { numericValue : Float
+        , units : units
+        , unitLabel : String
+        , length : Compatible
+        , lengthOrAuto : Compatible
+        , lengthOrNumber : Compatible
+        , lengthOrNone : Compatible
+        , lengthOrMinMaxDimension : Compatible
+        , lengthOrNoneOrMinMaxDimension : Compatible
+        , textIndent : Compatible
+        , flexBasis : Compatible
+        , absoluteLength : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , fontSize : Compatible
+        , lengthOrAutoOrCoverOrContain : Compatible
+        , calc : Compatible
+        }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/transform#Values>
 -}
 type alias Transform compatible =
-    { compatible | value : String, transform : Compatible }
+    Value { compatible | transform : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/angle>
 -}
 type alias Angle compatible =
-    { compatible | value : String, angle : Compatible }
+    Value { compatible | angle : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values>
 -}
 type alias AngleOrDirection compatible =
-    { compatible | value : String, angleOrDirection : Compatible }
+    Value { compatible | angleOrDirection : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style#Values>
 -}
 type alias TextDecorationStyle compatible =
-    { compatible | value : String, textDecorationStyle : Compatible }
+    Value { compatible | textDecorationStyle : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color#Values>
 -}
 type alias TextEmphasisColor compatible =
-    { compatible | value : String, textDecorationStyle : Compatible }
+    Value { compatible | textDecorationStyle : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values>
 -}
 type alias Position compatible =
-    { compatible | value : String, position : Compatible }
+    Value { compatible | position : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values>
 -}
 type alias BorderStyle compatible =
-    { compatible | value : String, borderStyle : Compatible }
+    Value { compatible | borderStyle : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse>
 -}
 type alias BorderCollapse compatible =
-    { compatible | value : String, borderCollapse : Compatible }
+    Value { compatible | borderCollapse : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box#Values>
 -}
 type alias TransformBox compatible =
-    { compatible | value : String, transformBox : Compatible }
+    Value { compatible | transformBox : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation#Values>
 -}
 type alias TextOrientation compatible =
-    { compatible | value : String, textOrientation : Compatible }
+    Value { compatible | textOrientation : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style#Values>
 -}
 type alias TransformStyle compatible =
-    { compatible | value : String, transformStyle : Compatible }
+    Value { compatible | transformStyle : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent#Values>
 -}
 type alias TextIndent compatible =
-    { compatible | value : String, textIndent : Compatible }
+    Value { compatible | textIndent : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values>
 -}
 type alias TextOverflow compatible =
-    { compatible | value : String, textOverflow : Compatible }
+    Value { compatible | textOverflow : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values>
 -}
 type alias TextTransform compatible =
-    { compatible | value : String, textTransform : Compatible }
+    Value { compatible | textTransform : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values>
 -}
 type alias TextRendering compatible =
-    { compatible | value : String, textRendering : Compatible }
+    Value { compatible | textRendering : Compatible }
 
 
 {-| <https://www.microsoft.com/typography/otspec/featurelist.htm>
 -}
 type alias FeatureTagValue compatible =
-    { compatible | value : String, featureTagValue : Compatible }
+    Value { compatible | featureTagValue : Compatible }
 
 
 {-| Because `left` and `right` are both common properties and common values
@@ -1764,13 +1745,13 @@ type alias VerticalAlign a b =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>
 -}
 type alias Cursor compatible =
-    { compatible | value : String, cursor : Compatible }
+    Value { compatible | cursor : Compatible }
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/outline#Values>
 -}
 type alias Outline compatible =
-    { compatible | value : String, outline : Compatible }
+    Value { compatible | outline : Compatible }
 
 
 
@@ -1811,9 +1792,7 @@ type alias NonMixable =
 -}
 transparent : ColorValue NonMixable
 transparent =
-    { value = "transparent"
-    , color = Compatible
-    }
+    Value "transparent"
 
 
 {-| The [`currentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentColor_keyword)
@@ -1821,9 +1800,7 @@ value.
 -}
 currentColor : ColorValue NonMixable
 currentColor =
-    { value = "currentColor"
-    , color = Compatible
-    }
+    Value "currentColor"
 
 
 {-| This can represent:
@@ -1832,17 +1809,13 @@ a `visible` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overfl
 a `visible` [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) value.
 -}
 visible :
-    { value : String
-    , overflow : Compatible
-    , visibility : Compatible
-    , pointerEvents : Compatible
-    }
+    Value
+        { overflow : Compatible
+        , visibility : Compatible
+        , pointerEvents : Compatible
+        }
 visible =
-    { value = "visible"
-    , overflow = Compatible
-    , visibility = Compatible
-    , pointerEvents = Compatible
-    }
+    Value "visible"
 
 
 {-| The `scroll` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
@@ -1850,57 +1823,43 @@ This can also represent a `scroll` [`background-attachment`](https://developer.m
 It can also be used in the overflow-block and oveflow-line media features.
 -}
 scroll :
-    { value : String
-    , scroll : Compatible
-    , overflow : Compatible
-    , backgroundAttachment : Compatible
-    , blockAxisOverflow : Compatible
-    , inlineAxisOverflow : Compatible
-    }
+    Value
+        { scroll : Compatible
+        , overflow : Compatible
+        , backgroundAttachment : Compatible
+        , blockAxisOverflow : Compatible
+        , inlineAxisOverflow : Compatible
+        }
 scroll =
-    { value = "scroll"
-    , scroll = Compatible
-    , overflow = Compatible
-    , backgroundAttachment = Compatible
-    , blockAxisOverflow = Compatible
-    , inlineAxisOverflow = Compatible
-    }
+    Value "scroll"
 
 
 {-| The `break-word` value for the [`overflow-wrap`](https://developer.mozilla.org/en/docs/Web/CSS/overflow-wrap#Values) property.
 -}
 breakWord : Wrap {}
 breakWord =
-    { value = "break-word"
-    , overflowWrap = Compatible
-    }
+    Value "break-word"
 
 
 {-| The `both` value for the [`resize`](https://developer.mozilla.org/en/docs/Web/CSS/resize#Values) property.
 -}
 both : Resize {}
 both =
-    { value = "both"
-    , resize = Compatible
-    }
+    Value "both"
 
 
 {-| The `horizontal` value for the [`resize`](https://developer.mozilla.org/en/docs/Web/CSS/resize#Values) property.
 -}
 horizontal : Resize {}
 horizontal =
-    { value = "horizontal"
-    , resize = Compatible
-    }
+    Value "horizontal"
 
 
 {-| The `vertical` value for the [`resize`](https://developer.mozilla.org/en/docs/Web/CSS/resize#Values) property.
 -}
 vertical : Resize {}
 vertical =
-    { value = "vertical"
-    , resize = Compatible
-    }
+    Value "vertical"
 
 
 {-| The `multiply` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#multiply).
@@ -2005,42 +1964,28 @@ luminosity =
 -}
 paddingBox : BackgroundClip {}
 paddingBox =
-    { value = "padding-box"
-    , backgroundClip = Compatible
-    }
+    Value "padding-box"
 
 
 {-| The `url` [`background-image`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image) value.
 -}
 url : String -> BackgroundImage {}
 url urlValue =
-    { value = "url(" ++ urlValue ++ ")"
-    , backgroundImage = Compatible
-    }
+    Value ("url(" ++ urlValue ++ ")")
 
 
 {-| The `cover` [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) value.
 -}
-cover :
-    { value : String
-    , lengthOrAutoOrCoverOrContain : Compatible
-    }
+cover : Value { lengthOrAutoOrCoverOrContain : Compatible }
 cover =
-    { value = "cover"
-    , lengthOrAutoOrCoverOrContain = Compatible
-    }
+    Value "cover"
 
 
 {-| The `contain` [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) value.
 -}
-contain :
-    { value : String
-    , lengthOrAutoOrCoverOrContain : Compatible
-    }
+contain : Value { lengthOrAutoOrCoverOrContain : Compatible }
 contain =
-    { value = "contain"
-    , lengthOrAutoOrCoverOrContain = Compatible
-    }
+    Value "contain"
 
 
 {-| `hidden` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
@@ -2051,69 +1996,65 @@ as well as a `hidden` [`visibility`](https://developer.mozilla.org/en-US/docs/We
 -}
 hidden : Overflow (BorderStyle (Visibility {}))
 hidden =
-    { value = "hidden"
-    , overflow = Compatible
-    , borderStyle = Compatible
-    , visibility = Compatible
-    }
+    Value "hidden"
 
 
 {-| -}
 type alias BasicProperty =
-    { value : String
-    , all : Compatible
-    , alignItems : Compatible
-    , borderStyle : Compatible
-    , boxSizing : Compatible
-    , color : Compatible
-    , cursor : Compatible
-    , display : Compatible
-    , flexBasis : Compatible
-    , flexWrap : Compatible
-    , flexDirection : Compatible
-    , flexDirectionOrWrap : Compatible
-    , justifyContent : Compatible
-    , none : Compatible
-    , number : Compatible
-    , outline : Compatible
-    , overflow : Compatible
-    , pointerEvents : Compatible
-    , visibility : Compatible
-    , textDecorationLine : Compatible
-    , textRendering : Compatible
-    , textIndent : Compatible
-    , textDecorationStyle : Compatible
-    , textTransform : Compatible
-    , length : Compatible
-    , lengthOrAuto : Compatible
-    , lengthOrNone : Compatible
-    , lengthOrNumber : Compatible
-    , lengthOrMinMaxDimension : Compatible
-    , lengthOrNoneOrMinMaxDimension : Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
-    , listStyleType : Compatible
-    , listStylePosition : Compatible
-    , listStyleTypeOrPositionOrImage : Compatible
-    , fontFamily : Compatible
-    , fontSize : Compatible
-    , fontStyle : Compatible
-    , fontWeight : Compatible
-    , fontVariant : Compatible
-    , units : IncompatibleUnits
-    , numericValue : Float
-    , unitLabel : String
-    , backgroundRepeat : Compatible
-    , backgroundRepeatShorthand : Compatible
-    , backgroundAttachment : Compatible
-    , backgroundBlendMode : Compatible
-    , backgroundOrigin : Compatible
-    , backgroundImage : Compatible
-    , lengthOrAutoOrCoverOrContain : Compatible
-    , intOrAuto : Compatible
-    , touchAction : Compatible
-    , whiteSpace : Compatible
-    , tableLayout : Compatible
-    }
+    Value
+        { all : Compatible
+        , alignItems : Compatible
+        , borderStyle : Compatible
+        , boxSizing : Compatible
+        , color : Compatible
+        , cursor : Compatible
+        , display : Compatible
+        , flexBasis : Compatible
+        , flexWrap : Compatible
+        , flexDirection : Compatible
+        , flexDirectionOrWrap : Compatible
+        , justifyContent : Compatible
+        , none : Compatible
+        , number : Compatible
+        , outline : Compatible
+        , overflow : Compatible
+        , pointerEvents : Compatible
+        , visibility : Compatible
+        , textDecorationLine : Compatible
+        , textRendering : Compatible
+        , textIndent : Compatible
+        , textDecorationStyle : Compatible
+        , textTransform : Compatible
+        , length : Compatible
+        , lengthOrAuto : Compatible
+        , lengthOrNone : Compatible
+        , lengthOrNumber : Compatible
+        , lengthOrMinMaxDimension : Compatible
+        , lengthOrNoneOrMinMaxDimension : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , listStyleType : Compatible
+        , listStylePosition : Compatible
+        , listStyleTypeOrPositionOrImage : Compatible
+        , fontFamily : Compatible
+        , fontSize : Compatible
+        , fontStyle : Compatible
+        , fontWeight : Compatible
+        , fontVariant : Compatible
+        , units : IncompatibleUnits
+        , numericValue : Float
+        , unitLabel : String
+        , backgroundRepeat : Compatible
+        , backgroundRepeatShorthand : Compatible
+        , backgroundAttachment : Compatible
+        , backgroundBlendMode : Compatible
+        , backgroundOrigin : Compatible
+        , backgroundImage : Compatible
+        , lengthOrAutoOrCoverOrContain : Compatible
+        , intOrAuto : Compatible
+        , touchAction : Compatible
+        , whiteSpace : Compatible
+        , tableLayout : Compatible
+        }
 
 
 {-| The [`unset`](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) value.
@@ -2121,7 +2062,7 @@ Any CSS property can be set to this value.
 -}
 unset : BasicProperty
 unset =
-    { initial | value = "unset" }
+    Value "unset"
 
 
 {-| The [`inherit`](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) value.
@@ -2129,7 +2070,7 @@ Any CSS property can be set to this value.
 -}
 inherit : BasicProperty
 inherit =
-    { initial | value = "inherit" }
+    Value "inherit"
 
 
 {-| The [`initial`](https://developer.mozilla.org/en-US/docs/Web/CSS/initial) value.
@@ -2137,60 +2078,7 @@ Any CSS property can be set to this value.
 -}
 initial : BasicProperty
 initial =
-    { value = "initial"
-    , overflow = Compatible
-    , visibility = Compatible
-    , none = Compatible
-    , number = Compatible
-    , textDecorationLine = Compatible
-    , textRendering = Compatible
-    , textIndent = Compatible
-    , textDecorationStyle = Compatible
-    , textTransform = Compatible
-    , borderStyle = Compatible
-    , boxSizing = Compatible
-    , color = Compatible
-    , cursor = Compatible
-    , display = Compatible
-    , all = Compatible
-    , alignItems = Compatible
-    , justifyContent = Compatible
-    , length = Compatible
-    , lengthOrAuto = Compatible
-    , lengthOrNone = Compatible
-    , lengthOrNumber = Compatible
-    , lengthOrMinMaxDimension = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    , listStyleType = Compatible
-    , listStylePosition = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    , flexBasis = Compatible
-    , flexWrap = Compatible
-    , flexDirection = Compatible
-    , flexDirectionOrWrap = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , fontFamily = Compatible
-    , fontSize = Compatible
-    , fontStyle = Compatible
-    , fontWeight = Compatible
-    , fontVariant = Compatible
-    , outline = Compatible
-    , pointerEvents = Compatible
-    , units = IncompatibleUnits
-    , numericValue = 0
-    , unitLabel = ""
-    , backgroundRepeat = Compatible
-    , backgroundRepeatShorthand = Compatible
-    , backgroundAttachment = Compatible
-    , backgroundBlendMode = Compatible
-    , backgroundOrigin = Compatible
-    , backgroundImage = Compatible
-    , lengthOrAutoOrCoverOrContain = Compatible
-    , intOrAuto = Compatible
-    , touchAction = Compatible
-    , whiteSpace = Compatible
-    , tableLayout = Compatible
-    }
+    Value "initial"
 
 
 {-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())
@@ -2362,27 +2250,21 @@ hslaToRgba value hue saturation lightness hslAlpha =
 -}
 optimizeSpeed : TextRendering {}
 optimizeSpeed =
-    { value = "optimizeSpeed"
-    , textRendering = Compatible
-    }
+    Value "optimizeSpeed"
 
 
 {-| `optimizeLegibility` [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values) value
 -}
 optimizeLegibility : TextRendering {}
 optimizeLegibility =
-    { value = "optimizeLegibility"
-    , textRendering = Compatible
-    }
+    Value "optimizeLegibility"
 
 
 {-| `geometricPrecision` [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values) value
 -}
 geometricPrecision : TextRendering {}
 geometricPrecision =
-    { value = "geometricPrecision"
-    , textRendering = Compatible
-    }
+    Value "geometricPrecision"
 
 
 
@@ -2393,18 +2275,14 @@ geometricPrecision =
 -}
 hanging : TextIndent {}
 hanging =
-    { value = "hanging"
-    , textIndent = Compatible
-    }
+    Value "hanging"
 
 
 {-| `each-line` [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent#Values) value
 -}
 eachLine : TextIndent {}
 eachLine =
-    { value = "each-line"
-    , textIndent = Compatible
-    }
+    Value "each-line"
 
 
 
@@ -2415,27 +2293,21 @@ eachLine =
 -}
 mixed : TextOrientation {}
 mixed =
-    { value = "mixed"
-    , textOrientation = Compatible
-    }
+    Value "mixed"
 
 
 {-| `upright` [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation#Values) value
 -}
 upright : TextOrientation {}
 upright =
-    { value = "upright"
-    , textOrientation = Compatible
-    }
+    Value "upright"
 
 
 {-| `sideways` [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientationEValues) value
 -}
 sideways : TextOrientation {}
 sideways =
-    { value = "sideways"
-    , textOrientation = Compatible
-    }
+    Value "sideways"
 
 
 
@@ -2446,54 +2318,42 @@ sideways =
 -}
 capitalize : TextTransform {}
 capitalize =
-    { value = "capitalize"
-    , textTransform = Compatible
-    }
+    Value "capitalize"
 
 
 {-| `uppercase` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
 uppercase : TextTransform {}
 uppercase =
-    { value = "uppercase"
-    , textTransform = Compatible
-    }
+    Value "uppercase"
 
 
 {-| `lowercase` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
 lowercase : TextTransform {}
 lowercase =
-    { value = "lowercase"
-    , textTransform = Compatible
-    }
+    Value "lowercase"
 
 
 {-| `full-width` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
 fullWidth : TextTransform {}
 fullWidth =
-    { value = "full-width"
-    , textTransform = Compatible
-    }
+    Value "full-width"
 
 
 {-| `ellipsis` [`text-overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values) value
 -}
 ellipsis : TextOverflow {}
 ellipsis =
-    { value = "ellipsis"
-    , textOverflow = Compatible
-    }
+    Value "ellipsis"
 
 
 {-| `clip` [`text-overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values) value
 -}
 clip : TextOverflow {}
 clip =
-    { value = "clip"
-    , textOverflow = Compatible
-    }
+    Value "clip"
 
 
 
@@ -2504,85 +2364,63 @@ clip =
 -}
 wavy : TextDecorationStyle {}
 wavy =
-    { value = "wavy"
-    , textDecorationStyle = Compatible
-    }
+    Value "wavy"
 
 
 {-| A `dotted` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 dotted : BorderStyle (TextDecorationStyle {})
 dotted =
-    { value = "dotted"
-    , borderStyle = Compatible
-    , textDecorationStyle = Compatible
-    }
+    Value "dotted"
 
 
 {-| A `dashed` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 dashed : BorderStyle (TextDecorationStyle {})
 dashed =
-    { value = "dashed"
-    , borderStyle = Compatible
-    , textDecorationStyle = Compatible
-    }
+    Value "dashed"
 
 
 {-| A `solid` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 solid : BorderStyle (TextDecorationStyle {})
 solid =
-    { value = "solid"
-    , borderStyle = Compatible
-    , textDecorationStyle = Compatible
-    }
+    Value "solid"
 
 
 {-| A `double` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 double : BorderStyle (TextDecorationStyle {})
 double =
-    { value = "double"
-    , borderStyle = Compatible
-    , textDecorationStyle = Compatible
-    }
+    Value "double"
 
 
 {-| A `groove` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 groove : BorderStyle {}
 groove =
-    { value = "groove"
-    , borderStyle = Compatible
-    }
+    Value "groove"
 
 
 {-| A `ridge` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 ridge : BorderStyle {}
 ridge =
-    { value = "ridge"
-    , borderStyle = Compatible
-    }
+    Value "ridge"
 
 
 {-| An `inset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 inset : BorderStyle {}
 inset =
-    { value = "inset"
-    , borderStyle = Compatible
-    }
+    Value "inset"
 
 
 {-| An `outset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 outset : BorderStyle {}
 outset =
-    { value = "outset"
-    , borderStyle = Compatible
-    }
+    Value "outset"
 
 
 
@@ -2593,9 +2431,7 @@ outset =
 -}
 separate : BorderCollapse {}
 separate =
-    { value = "separate"
-    , borderCollapse = Compatible
-    }
+    Value "separate"
 
 
 {-| A `collapse` [border-collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse#Values).
@@ -2603,10 +2439,7 @@ This can also represent a `collapse` [`visibility`](https://developer.mozilla.or
 -}
 collapse : BorderCollapse (Visibility {})
 collapse =
-    { value = "collapse"
-    , borderCollapse = Compatible
-    , visibility = Compatible
-    }
+    Value "collapse"
 
 
 
@@ -2699,35 +2532,22 @@ lengthConverter units unitLabel numericValue =
 
 -}
 zero :
-    { value : String
-    , length : Compatible
-    , lengthOrNumber : Compatible
-    , lengthOrNone : Compatible
-    , lengthOrAuto : Compatible
-    , lengthOrMinMaxDimension : Compatible
-    , lengthOrNoneOrMinMaxDimension : Compatible
-    , number : Compatible
-    , outline : Compatible
-    , units : UnitlessInteger
-    , unitLabel : String
-    , numericValue : Float
-    , lengthOrAutoOrCoverOrContain : Compatible
-    }
+    Value
+        { length : Compatible
+        , lengthOrNumber : Compatible
+        , lengthOrNone : Compatible
+        , lengthOrAuto : Compatible
+        , lengthOrMinMaxDimension : Compatible
+        , lengthOrNoneOrMinMaxDimension : Compatible
+        , number : Compatible
+        , outline : Compatible
+        , units : UnitlessInteger
+        , unitLabel : String
+        , numericValue : Float
+        , lengthOrAutoOrCoverOrContain : Compatible
+        }
 zero =
-    { value = "0"
-    , length = Compatible
-    , lengthOrNumber = Compatible
-    , lengthOrNone = Compatible
-    , lengthOrAuto = Compatible
-    , lengthOrMinMaxDimension = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    , number = Compatible
-    , outline = Compatible
-    , units = UnitlessInteger
-    , unitLabel = ""
-    , numericValue = 0
-    , lengthOrAutoOrCoverOrContain = Compatible
-    }
+    Value "0"
 
 
 {-| [`pct`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pct) units.
@@ -2993,16 +2813,7 @@ which accept either length units or unitless numbers for some properties.
 -}
 int : Int -> IntOrAuto (LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (FontWeight (Number { numericValue : Float, unitLabel : String, units : UnitlessInteger }))))
 int val =
-    { value = numberToString val
-    , lengthOrNumber = Compatible
-    , number = Compatible
-    , fontWeight = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , intOrAuto = Compatible
-    , numericValue = toFloat val
-    , unitLabel = ""
-    , units = UnitlessInteger
-    }
+    Value (numberToString val)
 
 
 type UnitlessInteger
@@ -3014,14 +2825,7 @@ which accept unitless numbers.
 -}
 num : Float -> LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (Number { numericValue : Float, unitLabel : String, units : UnitlessFloat }))
 num val =
-    { value = numberToString val
-    , lengthOrNumber = Compatible
-    , number = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , numericValue = val
-    , unitLabel = ""
-    , units = UnitlessFloat
-    }
+    Value (numberToString val)
 
 
 type UnitlessFloat
@@ -3044,10 +2848,7 @@ type IncompatibleUnits
 
 angleConverter : String -> number -> AngleOrDirection (Angle {})
 angleConverter suffix num =
-    { value = numberToString num ++ suffix
-    , angle = Compatible
-    , angleOrDirection = Compatible
-    }
+    Value (numberToString num ++ suffix)
 
 
 {-| [`deg`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#deg) units.
@@ -3089,9 +2890,10 @@ turn =
 -}
 matrix : number -> number -> number -> number -> number -> number -> Transform {}
 matrix a b c d tx ty =
-    { value = cssFunction "matrix" (List.map numberToString [ a, b, c, d, tx, ty ])
-    , transform = Compatible
-    }
+    [ a, b, c, d, tx, ty ]
+        |> List.map numberToString
+        |> cssFunction "matrix"
+        |> Value
 
 
 {-| The [`matrix3d()`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#matrix3d()) transform-function.
@@ -3101,9 +2903,10 @@ matrix a b c d tx ty =
 -}
 matrix3d : number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> Transform {}
 matrix3d a1 a2 a3 a4 b1 b2 b3 b4 c1 c2 c3 c4 d1 d2 d3 d4 =
-    { value = cssFunction "matrix3d" (List.map numberToString [ a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4 ])
-    , transform = Compatible
-    }
+    [ a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4 ]
+        |> List.map numberToString
+        |> cssFunction "matrix3d"
+        |> Value
 
 
 {-| The [`perspective()`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#perspective()) transform-function.
@@ -3113,9 +2916,7 @@ matrix3d a1 a2 a3 a4 b1 b2 b3 b4 c1 c2 c3 c4 d1 d2 d3 d4 =
 -}
 perspective : number -> Transform {}
 perspective l =
-    { value = cssFunction "perspective" [ numberToString l ]
-    , transform = Compatible
-    }
+    Value (cssFunction "perspective" [ numberToString l ])
 
 
 {-| The [`rotate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotate()) transform-function.
@@ -3124,10 +2925,8 @@ perspective l =
 
 -}
 rotate : Angle compatible -> Transform {}
-rotate { value } =
-    { value = cssFunction "rotate" [ value ]
-    , transform = Compatible
-    }
+rotate (Value value) =
+    Value (cssFunction "rotate" [ value ])
 
 
 {-| The [`rotateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateX()) transform-function.
@@ -3136,10 +2935,8 @@ rotate { value } =
 
 -}
 rotateX : Angle compatible -> Transform {}
-rotateX { value } =
-    { value = cssFunction "rotateX" [ value ]
-    , transform = Compatible
-    }
+rotateX (Value value) =
+    Value (cssFunction "rotateX" [ value ])
 
 
 {-| The [`rotateY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateY()) transform-function.
@@ -3148,10 +2945,8 @@ rotateX { value } =
 
 -}
 rotateY : Angle compatible -> Transform {}
-rotateY { value } =
-    { value = cssFunction "rotateY" [ value ]
-    , transform = Compatible
-    }
+rotateY (Value value) =
+    Value (cssFunction "rotateY" [ value ])
 
 
 {-| The [`rotateZ`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateZ()) transform-function.
@@ -3160,10 +2955,8 @@ rotateY { value } =
 
 -}
 rotateZ : Angle compatible -> Transform {}
-rotateZ { value } =
-    { value = cssFunction "rotateZ" [ value ]
-    , transform = Compatible
-    }
+rotateZ (Value value) =
+    Value (cssFunction "rotateZ" [ value ])
 
 
 {-| The [`rotate3d`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotate3d()) transform-function.
@@ -3172,14 +2965,12 @@ rotateZ { value } =
 
 -}
 rotate3d : number -> number -> number -> Angle compatible -> Transform {}
-rotate3d x y z { value } =
+rotate3d x y z (Value value) =
     let
         coordsAsStrings =
             List.map numberToString [ x, y, z ]
     in
-    { value = cssFunction "rotate3d" (coordsAsStrings ++ [ value ])
-    , transform = Compatible
-    }
+    Value (cssFunction "rotate3d" (coordsAsStrings ++ [ value ]))
 
 
 {-| The [`scale`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale()) transform-function.
@@ -3190,9 +2981,7 @@ rotate3d x y z { value } =
 -}
 scale : number -> Transform {}
 scale x =
-    { value = cssFunction "scale" [ numberToString x ]
-    , transform = Compatible
-    }
+    Value (cssFunction "scale" [ numberToString x ])
 
 
 {-| The [`scale`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale()) transform-function.
@@ -3203,9 +2992,7 @@ scale x =
 -}
 scale2 : number -> number -> Transform {}
 scale2 x y =
-    { value = cssFunction "scale" (List.map numberToString [ x, y ])
-    , transform = Compatible
-    }
+    Value (cssFunction "scale" (List.map numberToString [ x, y ]))
 
 
 {-| The [`scaleX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scaleX()) transform-function.
@@ -3215,9 +3002,7 @@ scale2 x y =
 -}
 scaleX : number -> Transform {}
 scaleX x =
-    { value = cssFunction "scaleX" [ numberToString x ]
-    , transform = Compatible
-    }
+    Value (cssFunction "scaleX" [ numberToString x ])
 
 
 {-| The [`scaleY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scaleY()) transform-function.
@@ -3227,9 +3012,7 @@ scaleX x =
 -}
 scaleY : number -> Transform {}
 scaleY y =
-    { value = cssFunction "scaleY" [ numberToString y ]
-    , transform = Compatible
-    }
+    Value (cssFunction "scaleY" [ numberToString y ])
 
 
 {-| The [`scale3d`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale3d()) transform-function.
@@ -3239,9 +3022,7 @@ scaleY y =
 -}
 scale3d : number -> number -> number -> Transform {}
 scale3d x y z =
-    { value = cssFunction "scale3d" (List.map numberToString [ x, y, z ])
-    , transform = Compatible
-    }
+    Value (cssFunction "scale3d" (List.map numberToString [ x, y, z ]))
 
 
 {-| The [`skew`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skew()) transform-function.
@@ -3251,10 +3032,8 @@ scale3d x y z =
 
 -}
 skew : Angle compatible -> Transform {}
-skew { value } =
-    { value = cssFunction "skew" [ value ]
-    , transform = Compatible
-    }
+skew (Value value) =
+    Value (cssFunction "skew" [ value ])
 
 
 {-| The [`skew`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skew()) transform-function.
@@ -3264,10 +3043,8 @@ skew { value } =
 
 -}
 skew2 : Angle compatibleA -> Angle compatibleB -> Transform {}
-skew2 ax ay =
-    { value = cssFunction "skew" [ ax.value, ay.value ]
-    , transform = Compatible
-    }
+skew2 (Value ax) (Value ay) =
+    Value (cssFunction "skew" [ ax, ay ])
 
 
 {-| The [`skewX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skewX()) transform-function.
@@ -3276,10 +3053,8 @@ skew2 ax ay =
 
 -}
 skewX : Angle compatible -> Transform {}
-skewX { value } =
-    { value = cssFunction "skewX" [ value ]
-    , transform = Compatible
-    }
+skewX (Value value) =
+    Value (cssFunction "skewX" [ value ])
 
 
 {-| The [`skewY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skewY()) transform-function.
@@ -3288,10 +3063,8 @@ skewX { value } =
 
 -}
 skewY : Angle compatible -> Transform {}
-skewY { value } =
-    { value = cssFunction "skewY" [ value ]
-    , transform = Compatible
-    }
+skewY (Value value) =
+    Value (cssFunction "skewY" [ value ])
 
 
 {-| The [`translate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate()) transform-function.
@@ -3301,10 +3074,8 @@ skewY { value } =
 
 -}
 translate : Length compatible units -> Transform {}
-translate { value } =
-    { value = cssFunction "translate" [ value ]
-    , transform = Compatible
-    }
+translate (Value value) =
+    Value (cssFunction "translate" [ value ])
 
 
 {-| The [`translate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate()) transform-function.
@@ -3314,10 +3085,8 @@ translate { value } =
 
 -}
 translate2 : Length compatibleA unitsA -> Length compatibleB unitsB -> Transform {}
-translate2 tx ty =
-    { value = cssFunction "translate" [ tx.value, ty.value ]
-    , transform = Compatible
-    }
+translate2 (Value tx) (Value ty) =
+    Value (cssFunction "translate" [ tx, ty ])
 
 
 {-| The [`translateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateX()) transform-function.
@@ -3326,10 +3095,8 @@ translate2 tx ty =
 
 -}
 translateX : Length compatible units -> Transform {}
-translateX { value } =
-    { value = cssFunction "translateX" [ value ]
-    , transform = Compatible
-    }
+translateX (Value value) =
+    Value (cssFunction "translateX" [ value ])
 
 
 {-| The [`translateY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateY()) transform-function.
@@ -3338,10 +3105,8 @@ translateX { value } =
 
 -}
 translateY : Length compatible units -> Transform {}
-translateY { value } =
-    { value = cssFunction "translateY" [ value ]
-    , transform = Compatible
-    }
+translateY (Value value) =
+    Value (cssFunction "translateY" [ value ])
 
 
 {-| The [`translateZ`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateZ()) transform-function.
@@ -3350,10 +3115,8 @@ translateY { value } =
 
 -}
 translateZ : Length compatible units -> Transform {}
-translateZ { value } =
-    { value = cssFunction "translateZ" [ value ]
-    , transform = Compatible
-    }
+translateZ (Value value) =
+    Value (cssFunction "translateZ" [ value ])
 
 
 {-| The [`translateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateX()) transform-function.
@@ -3362,10 +3125,8 @@ translateZ { value } =
 
 -}
 translate3d : Length compatibleA unitsA -> Length compatibleB unitsB -> Length compatibleC unitsC -> Transform {}
-translate3d tx ty tz =
-    { value = cssFunction "translate3d" [ tx.value, ty.value, tz.value ]
-    , transform = Compatible
-    }
+translate3d (Value tx) (Value ty) (Value tz) =
+    Value (cssFunction "translate3d" [ tx, ty, tz ])
 
 
 {-| Sets [`transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
@@ -3409,9 +3170,7 @@ transform only =
 -}
 fillBox : TransformBox {}
 fillBox =
-    { value = "fill-box"
-    , transformBox = Compatible
-    }
+    Value "fill-box"
 
 
 {-| The `content-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
@@ -3419,10 +3178,7 @@ Can also be used as `content-box` value for the [`background-clip`](https://deve
 -}
 contentBox : BoxSizing (BackgroundClip {})
 contentBox =
-    { value = "content-box"
-    , boxSizing = Compatible
-    , backgroundClip = Compatible
-    }
+    Value "content-box"
 
 
 {-| The `border-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
@@ -3430,19 +3186,14 @@ Can also be used as `border-box` value for the [`background-clip`](https://devel
 -}
 borderBox : BoxSizing (BackgroundClip {})
 borderBox =
-    { value = "border-box"
-    , boxSizing = Compatible
-    , backgroundClip = Compatible
-    }
+    Value "border-box"
 
 
 {-| The `view-box` value for the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
 -}
 viewBox : TransformBox {}
 viewBox =
-    { value = "view-box"
-    , transformBox = Compatible
-    }
+    Value "view-box"
 
 
 {-| The [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
@@ -3466,18 +3217,14 @@ boxSizing =
 -}
 preserve3d : TransformStyle {}
 preserve3d =
-    { value = "preserve-3d"
-    , transformStyle = Compatible
-    }
+    Value "preserve-3d"
 
 
 {-| The `flat` value for the [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style) property.
 -}
 flat : TransformStyle {}
 flat =
-    { value = "flat"
-    , transformStyle = Compatible
-    }
+    Value "flat"
 
 
 {-| The [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style) property.
@@ -3501,19 +3248,13 @@ listStylePosition =
 {-| -}
 inside : ListStyle (ListStylePosition {})
 inside =
-    { value = "inside"
-    , listStylePosition = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "inside"
 
 
 {-| -}
 outside : ListStyle (ListStylePosition {})
 outside =
-    { value = "outside"
-    , listStylePosition = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "outside"
 
 
 
@@ -3530,271 +3271,181 @@ listStyleType =
 {-| -}
 disc : ListStyle (ListStyleType {})
 disc =
-    { value = "disc"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "disc"
 
 
 {-| -}
 circle : ListStyle (ListStyleType {})
 circle =
-    { value = "circle"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "circle"
 
 
 {-| -}
 square : ListStyle (ListStyleType {})
 square =
-    { value = "square"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "square"
 
 
 {-| -}
 decimal : ListStyle (ListStyleType {})
 decimal =
-    { value = "decimal"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "decimal"
 
 
 {-| -}
 decimalLeadingZero : ListStyle (ListStyleType {})
 decimalLeadingZero =
-    { value = "decimal-leading-zero"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "decimal-leading-zero"
 
 
 {-| -}
 lowerRoman : ListStyle (ListStyleType {})
 lowerRoman =
-    { value = "lower-roman"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "lower-roman"
 
 
 {-| -}
 upperRoman : ListStyle (ListStyleType {})
 upperRoman =
-    { value = "upper-roman"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "upper-roman"
 
 
 {-| -}
 lowerGreek : ListStyle (ListStyleType {})
 lowerGreek =
-    { value = "lower-greek"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "lower-greek"
 
 
 {-| -}
 upperGreek : ListStyle (ListStyleType {})
 upperGreek =
-    { value = "upper-greek"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "upper-greek"
 
 
 {-| -}
 lowerAlpha : ListStyle (ListStyleType {})
 lowerAlpha =
-    { value = "lower-alpha"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "lower-alpha"
 
 
 {-| -}
 upperAlpha : ListStyle (ListStyleType {})
 upperAlpha =
-    { value = "upper-alpha"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "upper-alpha"
 
 
 {-| -}
 lowerLatin : ListStyle (ListStyleType {})
 lowerLatin =
-    { value = "lower-latin"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "lower-latin"
 
 
 {-| -}
 upperLatin : ListStyle (ListStyleType {})
 upperLatin =
-    { value = "upper-latin"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "upper-latin"
 
 
 {-| -}
 arabicIndic : ListStyle (ListStyleType {})
 arabicIndic =
-    { value = "arabic-indic"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "arabic-indic"
 
 
 {-| -}
 armenian : ListStyle (ListStyleType {})
 armenian =
-    { value = "armenian"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "armenian"
 
 
 {-| -}
 bengali : ListStyle (ListStyleType {})
 bengali =
-    { value = "bengali"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "bengali"
 
 
 {-| -}
 cjkEarthlyBranch : ListStyle (ListStyleType {})
 cjkEarthlyBranch =
-    { value = "cjk-earthly-branch"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "cjk-earthly-branch"
 
 
 {-| -}
 cjkHeavenlyStem : ListStyle (ListStyleType {})
 cjkHeavenlyStem =
-    { value = "cjk-heavenly-stem"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "cjk-heavenly-stem"
 
 
 {-| -}
 devanagari : ListStyle (ListStyleType {})
 devanagari =
-    { value = "devanagari"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "devanagari"
 
 
 {-| -}
 georgian : ListStyle (ListStyleType {})
 georgian =
-    { value = "georgian"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "georgian"
 
 
 {-| -}
 gujarati : ListStyle (ListStyleType {})
 gujarati =
-    { value = "gujarati"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "gujarati"
 
 
 {-| -}
 gurmukhi : ListStyle (ListStyleType {})
 gurmukhi =
-    { value = "gurmukhi"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "gurmukhi"
 
 
 {-| -}
 kannada : ListStyle (ListStyleType {})
 kannada =
-    { value = "kannada"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "kannada"
 
 
 {-| -}
 khmer : ListStyle (ListStyleType {})
 khmer =
-    { value = "khmer"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "khmer"
 
 
 {-| -}
 lao : ListStyle (ListStyleType {})
 lao =
-    { value = "lao"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "lao"
 
 
 {-| -}
 malayalam : ListStyle (ListStyleType {})
 malayalam =
-    { value = "malayalam"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "malayalam"
 
 
 {-| -}
 myanmar : ListStyle (ListStyleType {})
 myanmar =
-    { value = "myanmar"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "myanmar"
 
 
 {-| -}
 oriya : ListStyle (ListStyleType {})
 oriya =
-    { value = "oriya"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "oriya"
 
 
 {-| -}
 telugu : ListStyle (ListStyleType {})
 telugu =
-    { value = "telugu"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "telugu"
 
 
 {-| -}
 thai : ListStyle (ListStyleType {})
 thai =
-    { value = "thai"
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    Value "thai"
 
 
 
@@ -3979,10 +3630,7 @@ flex-basis property.
 -}
 content : LengthOrNumberOrAutoOrNoneOrContent (FlexBasis {})
 content =
-    { value = "content"
-    , flexBasis = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    }
+    Value "content"
 
 
 {-| The[`wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values) value for the
@@ -3990,10 +3638,7 @@ flex-wrap property.
 -}
 wrap : FlexDirectionOrWrap (FlexWrap {})
 wrap =
-    { value = "wrap"
-    , flexWrap = Compatible
-    , flexDirectionOrWrap = Compatible
-    }
+    Value "wrap"
 
 
 {-| The[`wrap-reverse`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values) value for the
@@ -4001,7 +3646,7 @@ flex-wrap property.
 -}
 wrapReverse : FlexDirectionOrWrap (FlexWrap {})
 wrapReverse =
-    { wrap | value = "wrap-reverse" }
+    Value "wrap-reverse"
 
 
 {-| The[`flex-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#Values) value for the
@@ -4051,10 +3696,7 @@ flex-direction property.
 -}
 row : FlexDirectionOrWrap (FlexDirection {})
 row =
-    { value = "row"
-    , flexDirection = Compatible
-    , flexDirectionOrWrap = Compatible
-    }
+    Value "row"
 
 
 {-| The[`row-reverse`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
@@ -4062,7 +3704,7 @@ flex-direction property.
 -}
 rowReverse : FlexDirectionOrWrap (FlexDirection {})
 rowReverse =
-    { row | value = "row-reverse" }
+    Value "row-reverse"
 
 
 {-| The[`column`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
@@ -4070,7 +3712,7 @@ flex-direction property.
 -}
 column : FlexDirectionOrWrap (FlexDirection {})
 column =
-    { row | value = "column" }
+    Value "column"
 
 
 {-| The[`column-reverse`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
@@ -4078,7 +3720,7 @@ flex-direction property.
 -}
 columnReverse : FlexDirectionOrWrap (FlexDirection {})
 columnReverse =
-    { row | value = "column-reverse" }
+    Value "column-reverse"
 
 
 
@@ -4090,9 +3732,7 @@ text decoration line.
 -}
 underline : TextDecorationLine {}
 underline =
-    { value = "underline"
-    , textDecorationLine = Compatible
-    }
+    Value "underline"
 
 
 {-| An [`overline`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Value)
@@ -4100,9 +3740,7 @@ text decoration line.
 -}
 overline : TextDecorationLine {}
 overline =
-    { value = "overline"
-    , textDecorationLine = Compatible
-    }
+    Value "overline"
 
 
 {-| A [`line-through`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Value)
@@ -4110,9 +3748,7 @@ text decoration line.
 -}
 lineThrough : TextDecorationLine {}
 lineThrough =
-    { value = "line-through"
-    , textDecorationLine = Compatible
-    }
+    Value "line-through"
 
 
 
@@ -4123,67 +3759,49 @@ lineThrough =
 -}
 repeatX : BackgroundRepeatShorthand {}
 repeatX =
-    { value = "repeat-x"
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "repeat-x"
 
 
 {-| The `repeat-y` [`background-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) value.
 -}
 repeatY : BackgroundRepeatShorthand {}
 repeatY =
-    { value = "repeat-y"
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "repeat-y"
 
 
 {-| The `repeat` [`background-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) value.
 -}
 repeat : BackgroundRepeat {}
 repeat =
-    { value = "repeat"
-    , backgroundRepeat = Compatible
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "repeat"
 
 
 {-| The `space` [`background-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) value.
 -}
 space : BackgroundRepeat {}
 space =
-    { value = "space"
-    , backgroundRepeat = Compatible
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "space"
 
 
 {-| The `round` [`background-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) value.
 -}
 round : BackgroundRepeat {}
 round =
-    { value = "round"
-    , backgroundRepeat = Compatible
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "round"
 
 
 {-| The `no-repeat` [`background-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) value.
 -}
 noRepeat : BackgroundRepeat {}
 noRepeat =
-    { value = "no-repeat"
-    , backgroundRepeat = Compatible
-    , backgroundRepeatShorthand = Compatible
-    }
+    Value "no-repeat"
 
 
 {-| The `local` [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) value.
 -}
 local : BackgroundAttachment {}
 local =
-    { value = "local"
-    , backgroundAttachment = Compatible
-    }
+    Value "local"
 
 
 
@@ -4211,14 +3829,12 @@ linearGradient stop1 stop2 stops =
     -- TODO we should make this more permissive, e.g. compatibleA/compatibleB/compatibleC/compatibleD
     -- the only reason it isn't is that we happen to be using collectStops like this.
     -- We should just not use collectStops. Same with linearGradient2
-    { value =
-        [ stop1, stop2 ]
-            ++ stops
-            |> collectStops
-            |> cssFunction "linear-gradient"
-    , backgroundImage = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+    stop1
+        :: stop2
+        :: stops
+        |> collectStops
+        |> cssFunction "linear-gradient"
+        |> Value
 
 
 {-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
@@ -4233,26 +3849,27 @@ linearGradient2 :
     -> ColorStop compatibleA compatibleB unit
     -> List (ColorStop compatibleA compatibleB unit)
     -> BackgroundImage (ListStyle {})
-linearGradient2 dir stop1 stop2 stops =
-    { value =
-        [ stop1, stop2 ]
-            ++ stops
-            |> collectStops
-            |> (::) dir.value
-            |> cssFunction "linear-gradient"
-    , backgroundImage = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    }
+linearGradient2 (Value dir) stop1 stop2 stops =
+    stop1
+        :: stop2
+        :: stops
+        |> collectStops
+        |> (::) dir
+        |> cssFunction "linear-gradient"
+        |> Value
 
 
 collectStops : List (ColorStop compatibleA compatibleB unit) -> List String
 collectStops =
-    List.map <|
-        \( c, len ) ->
-            len
-                |> Maybe.map (String.cons ' ' << .value)
-                |> Maybe.withDefault ""
-                |> String.append c.value
+    List.map
+        (\( Value c, len ) ->
+            case len of
+                Nothing ->
+                    c
+
+                Just (Value len) ->
+                    c ++ " " ++ len
+        )
 
 
 {-| [`ColorStop`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
@@ -4273,72 +3890,56 @@ stop2 c len =
 -}
 toTop : AngleOrDirection {}
 toTop =
-    { value = "to top"
-    , angleOrDirection = Compatible
-    }
+    Value "to top"
 
 
 {-| Sets the direction to [`top right`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toTopRight : AngleOrDirection {}
 toTopRight =
-    { value = "to top right"
-    , angleOrDirection = Compatible
-    }
+    Value "to top right"
 
 
 {-| Sets the direction to [`right`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toRight : AngleOrDirection {}
 toRight =
-    { value = "to right"
-    , angleOrDirection = Compatible
-    }
+    Value "to right"
 
 
 {-| Sets the direction to [`bottom right`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toBottomRight : AngleOrDirection {}
 toBottomRight =
-    { value = "to bottom right"
-    , angleOrDirection = Compatible
-    }
+    Value "to bottom right"
 
 
 {-| Sets the direction to [`bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toBottom : AngleOrDirection {}
 toBottom =
-    { value = "to bottom"
-    , angleOrDirection = Compatible
-    }
+    Value "to bottom"
 
 
 {-| Sets the direction to [`bottom left`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toBottomLeft : AngleOrDirection {}
 toBottomLeft =
-    { value = "to bottom left"
-    , angleOrDirection = Compatible
-    }
+    Value "to bottom left"
 
 
 {-| Sets the direction to [`left`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toLeft : AngleOrDirection {}
 toLeft =
-    { value = "to left"
-    , angleOrDirection = Compatible
-    }
+    Value "to left"
 
 
 {-| Sets the direction to [`top left`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Values)
 -}
 toTopLeft : AngleOrDirection {}
 toTopLeft =
-    { value = "to top left"
-    , angleOrDirection = Compatible
-    }
+    Value "to top left"
 
 
 
@@ -4348,240 +3949,168 @@ toTopLeft =
 {-| -}
 block : Display {}
 block =
-    { value = "block"
-    , display = Compatible
-    }
+    Value "block"
 
 
 {-| -}
 inlineBlock : Display {}
 inlineBlock =
-    { value = "inline-block"
-    , display = Compatible
-    }
+    Value "inline-block"
 
 
 {-| Sets the display style to [`inline-flex`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 inlineFlex : Display {}
 inlineFlex =
-    { value = "inline-flex"
-    , display = Compatible
-    }
+    Value "inline-flex"
 
 
 {-| -}
 inline : Display {}
 inline =
-    { value = "inline"
-    , display = Compatible
-    }
+    Value "inline"
 
 
 {-| Sets the display style to [`table`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 table : Display {}
 table =
-    { value = "table"
-    , display = Compatible
-    }
+    Value "table"
 
 
 {-| Sets the display style to [`inline-table`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 inlineTable : Display {}
 inlineTable =
-    { value = "inline-table"
-    , display = Compatible
-    }
+    Value "inline-table"
 
 
 {-| Sets the display style to [`table-row`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableRow : Display {}
 tableRow =
-    { value = "table-row"
-    , display = Compatible
-    }
+    Value "table-row"
 
 
 {-| Sets the display style to [`table-cell`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableCell : Display {}
 tableCell =
-    { value = "table-cell"
-    , display = Compatible
-    }
+    Value "table-cell"
 
 
 {-| Sets the display style to [`table-column`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableColumn : Display {}
 tableColumn =
-    { value = "table-column"
-    , display = Compatible
-    }
+    Value "table-column"
 
 
 {-| Sets the display style to [`table-caption`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableCaption : Display {}
 tableCaption =
-    { value = "table-caption"
-    , display = Compatible
-    }
+    Value "table-caption"
 
 
 {-| Sets the display style to [`table-row-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableRowGroup : Display {}
 tableRowGroup =
-    { value = "table-row-group"
-    , display = Compatible
-    }
+    Value "table-row-group"
 
 
 {-| Sets the display style to [`table-column-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableColumnGroup : Display {}
 tableColumnGroup =
-    { value = "table-column-group"
-    , display = Compatible
-    }
+    Value "table-column-group"
 
 
 {-| Sets the display style to [`table-header-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableHeaderGroup : Display {}
 tableHeaderGroup =
-    { value = "table-header-group"
-    , display = Compatible
-    }
+    Value "table-header-group"
 
 
 {-| Sets the display style to [`table-footer-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableFooterGroup : Display {}
 tableFooterGroup =
-    { value = "table-footer-group"
-    , display = Compatible
-    }
+    Value "table-footer-group"
 
 
 {-| -}
 listItem : Display {}
 listItem =
-    { value = "list-item"
-    , display = Compatible
-    }
+    Value "list-item"
 
 
 {-| -}
 inlineListItem : Display {}
 inlineListItem =
-    { value = "inline-list-item"
-    , display = Compatible
-    }
+    Value "inline-list-item"
 
 
 {-| -}
 none :
-    { borderStyle : Compatible
-    , cursor : Compatible
-    , display : Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
-    , none : Compatible
-    , lengthOrNone : Compatible
-    , lengthOrNoneOrMinMaxDimension : Compatible
-    , listStyleType : Compatible
-    , listStyleTypeOrPositionOrImage : Compatible
-    , outline : Compatible
-    , pointerEvents : Compatible
-    , resize : Compatible
-    , textDecorationLine : Compatible
-    , transform : Compatible
-    , backgroundImage : Compatible
-    , value : String
-    , textTransform : Compatible
-    , touchAction : Compatible
-    , updateFrequency : Compatible
-    , blockAxisOverflow : Compatible
-    , inlineAxisOverflow : Compatible
-    , pointerDevice : Compatible
-    , hoverCapability : Compatible
-    , scriptingSupport : Compatible
-    }
+    Value
+        { borderStyle : Compatible
+        , cursor : Compatible
+        , display : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , none : Compatible
+        , lengthOrNone : Compatible
+        , lengthOrNoneOrMinMaxDimension : Compatible
+        , listStyleType : Compatible
+        , listStyleTypeOrPositionOrImage : Compatible
+        , outline : Compatible
+        , pointerEvents : Compatible
+        , resize : Compatible
+        , textDecorationLine : Compatible
+        , transform : Compatible
+        , backgroundImage : Compatible
+        , value : String
+        , textTransform : Compatible
+        , touchAction : Compatible
+        , updateFrequency : Compatible
+        , blockAxisOverflow : Compatible
+        , inlineAxisOverflow : Compatible
+        , pointerDevice : Compatible
+        , hoverCapability : Compatible
+        , scriptingSupport : Compatible
+        }
 none =
-    { value = "none"
-    , cursor = Compatible
-    , none = Compatible
-    , lengthOrNone = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , textDecorationLine = Compatible
-    , listStyleType = Compatible
-    , listStyleTypeOrPositionOrImage = Compatible
-    , display = Compatible
-    , outline = Compatible
-    , pointerEvents = Compatible
-    , resize = Compatible
-    , transform = Compatible
-    , borderStyle = Compatible
-    , backgroundImage = Compatible
-    , textTransform = Compatible
-    , touchAction = Compatible
-    , updateFrequency = Compatible
-    , blockAxisOverflow = Compatible
-    , inlineAxisOverflow = Compatible
-    , pointerDevice = Compatible
-    , hoverCapability = Compatible
-    , scriptingSupport = Compatible
-    }
+    Value "none"
 
 
 {-| -}
 auto :
-    { lengthOrAuto : Compatible
-    , overflow : Compatible
-    , textRendering : Compatible
-    , flexBasis : Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
-    , alignItemsOrAuto : Compatible
-    , justifyContentOrAuto : Compatible
-    , cursor : Compatible
-    , value : String
-    , lengthOrAutoOrCoverOrContain : Compatible
-    , intOrAuto : Compatible
-    , pointerEvents : Compatible
-    , touchAction : Compatible
-    , tableLayout : Compatible
-    }
+    Value
+        { lengthOrAuto : Compatible
+        , overflow : Compatible
+        , textRendering : Compatible
+        , flexBasis : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , alignItemsOrAuto : Compatible
+        , justifyContentOrAuto : Compatible
+        , cursor : Compatible
+        , value : String
+        , lengthOrAutoOrCoverOrContain : Compatible
+        , intOrAuto : Compatible
+        , pointerEvents : Compatible
+        , touchAction : Compatible
+        , tableLayout : Compatible
+        }
 auto =
-    { value = "auto"
-    , cursor = Compatible
-    , flexBasis = Compatible
-    , overflow = Compatible
-    , textRendering = Compatible
-    , lengthOrAuto = Compatible
-    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
-    , alignItemsOrAuto = Compatible
-    , lengthOrAutoOrCoverOrContain = Compatible
-    , justifyContentOrAuto = Compatible
-    , intOrAuto = Compatible
-    , pointerEvents = Compatible
-    , touchAction = Compatible
-    , tableLayout = Compatible
-    }
+    Value "auto"
 
 
 {-| -}
 noWrap : WhiteSpace (FlexDirectionOrWrap (FlexWrap {}))
 noWrap =
-    { value = "nowrap"
-    , whiteSpace = Compatible
-    , flexWrap = Compatible
-    , flexDirectionOrWrap = Compatible
-    }
+    Value "nowrap"
 
 
 
@@ -4660,33 +4189,33 @@ position =
 
 
 prop1 : String -> Value a -> Style
-prop1 key arg =
-    property key arg.value
+prop1 key (Value arg) =
+    property key arg
 
 
 prop2 : String -> Value a -> Value b -> Style
-prop2 key argA argB =
-    property key (String.join " " [ argA.value, argB.value ])
+prop2 key (Value argA) (Value argB) =
+    property key (String.join " " [ argA, argB ])
 
 
 prop3 : String -> Value a -> Value b -> Value c -> Style
-prop3 key argA argB argC =
-    property key (String.join " " [ argA.value, argB.value, argC.value ])
+prop3 key (Value argA) (Value argB) (Value argC) =
+    property key (String.join " " [ argA, argB, argC ])
 
 
 prop4 : String -> Value a -> Value b -> Value c -> Value d -> Style
-prop4 key argA argB argC argD =
-    property key (String.join " " [ argA.value, argB.value, argC.value, argD.value ])
+prop4 key (Value argA) (Value argB) (Value argC) (Value argD) =
+    property key (String.join " " [ argA, argB, argC, argD ])
 
 
 prop5 : String -> Value a -> Value b -> Value c -> Value d -> Value e -> Style
-prop5 key argA argB argC argD argE =
-    property key (String.join " " [ argA.value, argB.value, argC.value, argD.value, argE.value ])
+prop5 key (Value argA) (Value argB) (Value argC) (Value argD) (Value argE) =
+    property key (String.join " " [ argA, argB, argC, argD, argE ])
 
 
 prop6 : String -> Value a -> Value b -> Value c -> Value d -> Value e -> Value f -> Style
-prop6 key argA argB argC argD argE argF =
-    property key (String.join " " [ argA.value, argB.value, argC.value, argD.value, argE.value, argF.value ])
+prop6 key (Value argA) (Value argB) (Value argC) (Value argD) (Value argE) (Value argF) =
+    property key (String.join " " [ argA, argB, argC, argD, argE, argF ])
 
 
 {-| Sets ['float'](https://developer.mozilla.org/en-US/docs/Web/CSS/float)
@@ -4706,8 +4235,8 @@ float fn =
 
 -}
 textDecorationColor : ColorValue compatible -> Style
-textDecorationColor c =
-    property "text-decoration-color" c.value
+textDecorationColor (Value c) =
+    property "text-decoration-color" c
 
 
 {-| Sets ['text-emphasis-color'](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color)
@@ -4716,8 +4245,8 @@ textDecorationColor c =
 
 -}
 textEmphasisColor : ColorValue compatible -> Style
-textEmphasisColor c =
-    property "text-emphasis-color" c.value
+textEmphasisColor (Value c) =
+    property "text-emphasis-color" c
 
 
 {-| Sets [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last).
@@ -5430,7 +4959,7 @@ right =
 -}
 maxContent : MinMaxDimension {}
 maxContent =
-    { fillAvailable | value = "max-content" }
+    Value "max-content"
 
 
 {-| The `min-content` value for
@@ -5441,7 +4970,7 @@ maxContent =
 -}
 minContent : MinMaxDimension {}
 minContent =
-    { fillAvailable | value = "min-content" }
+    Value "min-content"
 
 
 {-| The `fit-content` value for
@@ -5452,7 +4981,7 @@ minContent =
 -}
 fitContent : MinMaxDimension {}
 fitContent =
-    { fillAvailable | value = "fit-content" }
+    Value "fit-content"
 
 
 {-| The `fill-available` value for
@@ -5463,11 +4992,7 @@ fitContent =
 -}
 fillAvailable : MinMaxDimension {}
 fillAvailable =
-    { value = "fill-available"
-    , minMaxDimension = Compatible
-    , lengthOrMinMaxDimension = Compatible
-    , lengthOrNoneOrMinMaxDimension = Compatible
-    }
+    Value "fill-available"
 
 
 
@@ -5481,9 +5006,7 @@ fillAvailable =
 -}
 static : Position {}
 static =
-    { value = "static"
-    , position = Compatible
-    }
+    Value "static"
 
 
 {-| A `fixed` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
@@ -5495,17 +5018,13 @@ This can also be the `fixed` value for [`table-layout`](https://developer.mozill
 
 -}
 fixed :
-    { value : String
-    , position : Compatible
-    , backgroundAttachment : Compatible
-    , tableLayout : Compatible
-    }
+    Value
+        { position : Compatible
+        , backgroundAttachment : Compatible
+        , tableLayout : Compatible
+        }
 fixed =
-    { value = "fixed"
-    , position = Compatible
-    , backgroundAttachment = Compatible
-    , tableLayout = Compatible
-    }
+    Value "fixed"
 
 
 {-| A `sticky` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
@@ -5515,9 +5034,7 @@ fixed =
 -}
 sticky : Position {}
 sticky =
-    { value = "sticky"
-    , position = Compatible
-    }
+    Value "sticky"
 
 
 {-| A `relative` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
@@ -5527,9 +5044,7 @@ sticky =
 -}
 relative : Position {}
 relative =
-    { value = "relative"
-    , position = Compatible
-    }
+    Value "relative"
 
 
 {-| An `absolute` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
@@ -5539,9 +5054,7 @@ relative =
 -}
 absolute : Position {}
 absolute =
-    { value = "absolute"
-    , position = Compatible
-    }
+    Value "absolute"
 
 
 
@@ -5552,31 +5065,31 @@ absolute =
 {-| -}
 serif : FontFamily {}
 serif =
-    { value = "serif", fontFamily = Compatible }
+    Value "serif"
 
 
 {-| -}
 sansSerif : FontFamily {}
 sansSerif =
-    { value = "sans-serif", fontFamily = Compatible }
+    Value "sans-serif"
 
 
 {-| -}
 monospace : FontFamily {}
 monospace =
-    { value = "monospace", fontFamily = Compatible }
+    Value "monospace"
 
 
 {-| -}
 cursive : FontFamily {}
 cursive =
-    { value = "cursive", fontFamily = Compatible }
+    Value "cursive"
 
 
 {-| -}
 fantasy : FontFamily {}
 fantasy =
-    { value = "fantasy", fontFamily = Compatible }
+    Value "fantasy"
 
 
 
@@ -5586,93 +5099,84 @@ fantasy =
 {-| -}
 xxSmall : FontSize {}
 xxSmall =
-    { value = "xx-small", fontSize = Compatible }
+    Value "xx-small"
 
 
 {-| -}
 xSmall : FontSize {}
 xSmall =
-    { value = "x-small", fontSize = Compatible }
+    Value "x-small"
 
 
 {-| -}
 small : FontSize {}
 small =
-    { value = "small", fontSize = Compatible }
+    Value "small"
 
 
 {-| -}
 medium : FontSize {}
 medium =
-    { value = "medium", fontSize = Compatible }
+    Value "medium"
 
 
 {-| -}
 large : FontSize {}
 large =
-    { value = "large", fontSize = Compatible }
+    Value "large"
 
 
 {-| -}
 xLarge : FontSize {}
 xLarge =
-    { value = "x-large", fontSize = Compatible }
+    Value "x-large"
 
 
 {-| -}
 xxLarge : FontSize {}
 xxLarge =
-    { value = "xx-large", fontSize = Compatible }
+    Value "xx-large"
 
 
 {-| -}
 smaller : FontSize {}
 smaller =
-    { value = "smaller", fontSize = Compatible }
+    Value "smaller"
 
 
 {-| -}
 larger : FontSize {}
 larger =
-    { value = "larger", fontSize = Compatible }
+    Value "larger"
 
 
 
 -- Styles --
 
 
-type alias Normal =
-    { value : String
-    , fontStyle : Compatible
-    , fontWeight : Compatible
-    , featureTagValue : Compatible
-    , overflowWrap : Compatible
-    , whiteSpace : Compatible
-    }
-
-
 {-| -}
-normal : Normal
+normal :
+    Value
+        { fontStyle : Compatible
+        , fontWeight : Compatible
+        , featureTagValue : Compatible
+        , overflowWrap : Compatible
+        , whiteSpace : Compatible
+        }
 normal =
-    { value = "normal"
-    , fontStyle = Compatible
-    , fontWeight = Compatible
-    , featureTagValue = Compatible
-    , overflowWrap = Compatible
-    , whiteSpace = Compatible
-    }
+    Value "normal"
 
 
 {-| -}
 italic : FontStyle {}
 italic =
-    { value = "italic", fontStyle = Compatible }
+    Value "italic"
 
 
 {-| -}
 oblique : FontStyle {}
 oblique =
-    { value = "oblique", fontStyle = Compatible }
+    Value "oblique"
 
 
 
@@ -5682,25 +5186,19 @@ oblique =
 {-| -}
 bold : FontWeight {}
 bold =
-    { value = "bold"
-    , fontWeight = Compatible
-    }
+    Value "bold"
 
 
 {-| -}
 lighter : FontWeight {}
 lighter =
-    { value = "lighter"
-    , fontWeight = Compatible
-    }
+    Value "lighter"
 
 
 {-| -}
 bolder : FontWeight {}
 bolder =
-    { value = "bolder"
-    , fontWeight = Compatible
-    }
+    Value "bolder"
 
 
 
@@ -5711,37 +5209,37 @@ bolder =
 {-| -}
 smallCaps : FontVariantCaps {}
 smallCaps =
-    { value = "small-caps", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "small-caps"
 
 
 {-| -}
 allSmallCaps : FontVariantCaps {}
 allSmallCaps =
-    { value = "all-small-caps", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "all-small-caps"
 
 
 {-| -}
 petiteCaps : FontVariantCaps {}
 petiteCaps =
-    { value = "petite-caps", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "petite-caps"
 
 
 {-| -}
 allPetiteCaps : FontVariantCaps {}
 allPetiteCaps =
-    { value = "all-petite-caps", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "all-petite-caps"
 
 
 {-| -}
 unicase : FontVariantCaps {}
 unicase =
-    { value = "unicase", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "unicase"
 
 
 {-| -}
 titlingCaps : FontVariantCaps {}
 titlingCaps =
-    { value = "titling-caps", fontVariant = Compatible, fontVariantCaps = Compatible }
+    Value "titling-caps"
 
 
 
@@ -5751,73 +5249,49 @@ titlingCaps =
 {-| -}
 commonLigatures : FontVariantLigatures {}
 commonLigatures =
-    { value = "common-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "common-ligatures"
 
 
 {-| -}
 noCommonLigatures : FontVariantLigatures {}
 noCommonLigatures =
-    { value = "no-common-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "no-common-ligatures"
 
 
 {-| -}
 discretionaryLigatures : FontVariantLigatures {}
 discretionaryLigatures =
-    { value = "discretionary-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "discretionary-ligatures"
 
 
 {-| -}
 noDiscretionaryLigatures : FontVariantLigatures {}
 noDiscretionaryLigatures =
-    { value = "no-discretionary-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "no-discretionary-ligatures"
 
 
 {-| -}
 historicalLigatures : FontVariantLigatures {}
 historicalLigatures =
-    { value = "historical-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "historical-ligatures"
 
 
 {-| -}
 noHistoricalLigatures : FontVariantLigatures {}
 noHistoricalLigatures =
-    { value = "no-historical-ligatures"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "no-historical-ligatures"
 
 
 {-| -}
 contextual : FontVariantLigatures {}
 contextual =
-    { value = "context"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "context"
 
 
 {-| -}
 noContextual : FontVariantLigatures {}
 noContextual =
-    { value = "no-contextual"
-    , fontVariant = Compatible
-    , fontVariantLigatures = Compatible
-    }
+    Value "no-contextual"
 
 
 
@@ -5827,73 +5301,49 @@ noContextual =
 {-| -}
 liningNums : FontVariantNumeric {}
 liningNums =
-    { value = "lining-nums"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "lining-nums"
 
 
 {-| -}
 oldstyleNums : FontVariantNumeric {}
 oldstyleNums =
-    { value = "oldstyle-nums"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "oldstyle-nums"
 
 
 {-| -}
 proportionalNums : FontVariantNumeric {}
 proportionalNums =
-    { value = "proportional-nums"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "proportional-nums"
 
 
 {-| -}
 tabularNums : FontVariantNumeric {}
 tabularNums =
-    { value = "tabular-nums"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "tabular-nums"
 
 
 {-| -}
 diagonalFractions : FontVariantNumeric {}
 diagonalFractions =
-    { value = "diagonal-fractions"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "diagonal-fractions"
 
 
 {-| -}
 stackedFractions : FontVariantNumeric {}
 stackedFractions =
-    { value = "stacked-fractions"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "stacked-fractions"
 
 
 {-| -}
 ordinal : FontVariantNumeric {}
 ordinal =
-    { value = "ordinal"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "ordinal"
 
 
 {-| -}
 slashedZero : FontVariantNumeric {}
 slashedZero =
-    { value = "slashed-zero"
-    , fontVariant = Compatible
-    , fontVariantNumeric = Compatible
-    }
+    Value "slashed-zero"
 
 
 
@@ -5934,9 +5384,7 @@ with a particular integer value
 -}
 featureTag2 : String -> Int -> FeatureTagValue {}
 featureTag2 tag value =
-    { value = toString tag ++ " " ++ toString value
-    , featureTagValue = Compatible
-    }
+    Value (toString tag ++ " " ++ toString value)
 
 
 
@@ -6377,8 +5825,8 @@ borderImageWidth4 =
 
 -}
 borderBlockStartColor : ColorValue compatible -> Style
-borderBlockStartColor c =
-    property "border-block-start-color" c.value
+borderBlockStartColor (Value c) =
+    property "border-block-start-color" c
 
 
 {-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color)
@@ -6387,8 +5835,8 @@ borderBlockStartColor c =
 
 -}
 borderBottomColor : ColorValue compatible -> Style
-borderBottomColor c =
-    property "border-bottom-color" c.value
+borderBottomColor (Value c) =
+    property "border-bottom-color" c
 
 
 {-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)
@@ -6397,8 +5845,8 @@ borderBottomColor c =
 
 -}
 borderInlineStartColor : ColorValue compatible -> Style
-borderInlineStartColor c =
-    property "border-inline-start-color" c.value
+borderInlineStartColor (Value c) =
+    property "border-inline-start-color" c
 
 
 {-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color)
@@ -6407,8 +5855,8 @@ borderInlineStartColor c =
 
 -}
 borderInlineEndColor : ColorValue compatible -> Style
-borderInlineEndColor c =
-    property "border-inline-end-color" c.value
+borderInlineEndColor (Value c) =
+    property "border-inline-end-color" c
 
 
 {-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color)
@@ -6417,8 +5865,8 @@ borderInlineEndColor c =
 
 -}
 borderLeftColor : ColorValue compatible -> Style
-borderLeftColor c =
-    property "border-left-color" c.value
+borderLeftColor (Value c) =
+    property "border-left-color" c
 
 
 {-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color)
@@ -6427,8 +5875,8 @@ borderLeftColor c =
 
 -}
 borderRightColor : ColorValue compatible -> Style
-borderRightColor c =
-    property "border-right-color" c.value
+borderRightColor (Value c) =
+    property "border-right-color" c
 
 
 {-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color)
@@ -6437,8 +5885,8 @@ borderRightColor c =
 
 -}
 borderTopColor : ColorValue compatible -> Style
-borderTopColor c =
-    property "border-top-color" c.value
+borderTopColor (Value c) =
+    property "border-top-color" c
 
 
 {-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color)
@@ -6447,8 +5895,8 @@ borderTopColor c =
 
 -}
 borderBlockEndColor : ColorValue compatible -> Style
-borderBlockEndColor c =
-    property "border-block-end-color" c.value
+borderBlockEndColor (Value c) =
+    property "border-block-end-color" c
 
 
 {-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style)
@@ -6836,8 +6284,8 @@ borderSpacing2 =
 
 -}
 borderColor : ColorValue compatible -> Style
-borderColor c =
-    property "border-color" c.value
+borderColor (Value c) =
+    property "border-color" c
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -6849,12 +6297,10 @@ borderColor c =
 
 -}
 borderColor2 : ColorValue compatibleA -> ColorValue compatibleB -> Style
-borderColor2 c1 c2 =
-    let
-        value =
-            String.join " " [ c1.value, c2.value ]
-    in
-    property "border-color" value
+borderColor2 (Value c1) (Value c2) =
+    [ c1, c2 ]
+        |> String.join ""
+        |> property "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -6866,12 +6312,10 @@ borderColor2 c1 c2 =
 
 -}
 borderColor3 : ColorValue compatibleA -> ColorValue compatibleB -> ColorValue compatibleC -> Style
-borderColor3 c1 c2 c3 =
-    let
-        value =
-            String.join " " [ c1.value, c2.value, c3.value ]
-    in
-    property "border-color" value
+borderColor3 (Value c1) (Value c2) (Value c3) =
+    [ c1, c2, c3 ]
+        |> String.join " "
+        |> property "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -6883,12 +6327,10 @@ borderColor3 c1 c2 c3 =
 
 -}
 borderColor4 : ColorValue compatibleA -> ColorValue compatibleB -> ColorValue compatibleC -> ColorValue compatibleD -> Style
-borderColor4 c1 c2 c3 c4 =
-    let
-        value =
-            String.join " " [ c1.value, c2.value, c3.value, c4.value ]
-    in
-    property "border-color" value
+borderColor4 (Value c1) (Value c2) (Value c3) (Value c4) =
+    [ c1, c2, c3, c4 ]
+        |> String.join " "
+        |> property "border-color"
 
 
 {-| Sets [`outline`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline)
@@ -6923,8 +6365,8 @@ outline3 =
 
 -}
 outlineColor : ColorValue compatible -> Style
-outlineColor c =
-    property "outline-color" c.value
+outlineColor (Value c) =
+    property "outline-color" c
 
 
 {-| Sets [`outline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width)
@@ -7013,8 +6455,8 @@ whiteSpace =
 
 {-| -}
 backgroundColor : ColorValue compatible -> Style
-backgroundColor c =
-    property "background-color" c.value
+backgroundColor (Value c) =
+    property "background-color" c
 
 
 {-| Sets ['background-repeat'](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
@@ -7133,8 +6575,8 @@ backgroundSize2 =
 
 {-| -}
 color : ColorValue compatible -> Style
-color c =
-    property "color" c.value
+color (Value c) =
+    property "color" c
 
 
 
@@ -7163,8 +6605,8 @@ letterSpacing =
 
 {-| -}
 src_ : ImportType compatible -> String
-src_ value =
-    toString value.value
+src_ (Value value) =
+    toString value
 
 
 {-| -}
@@ -7211,7 +6653,7 @@ fontFamilies =
 
 -}
 fontFeatureSettings : FeatureTagValue a -> Style
-fontFeatureSettings { value } =
+fontFeatureSettings (Value value) =
     property "font-feature-settings" value
 
 
@@ -7223,7 +6665,7 @@ fontFeatureSettings { value } =
 fontFeatureSettingsList : List (FeatureTagValue a) -> Style
 fontFeatureSettingsList featureTagValues =
     featureTagValues
-        |> List.map .value
+        |> List.map (\(Value value) -> value)
         |> String.join ", "
         |> property "font-feature-settings"
 
@@ -7256,7 +6698,7 @@ fontStyle =
 
 -}
 fontWeight : FontWeight a -> Style
-fontWeight { value } =
+fontWeight (Value value) =
     property "font-weight" value
 
 
@@ -7340,205 +6782,205 @@ cursor =
 {-| -}
 default : Cursor {}
 default =
-    { value = "default", cursor = Compatible }
+    Value "default"
 
 
 {-| -}
 crosshair : Cursor {}
 crosshair =
-    { value = "crosshair", cursor = Compatible }
+    Value "crosshair"
 
 
 {-| -}
 contextMenu : Cursor {}
 contextMenu =
-    { value = "context-menu", cursor = Compatible }
+    Value "context-menu"
 
 
 {-| -}
 help : Cursor {}
 help =
-    { value = "help", cursor = Compatible }
+    Value "help"
 
 
 {-| -}
 pointer : Cursor {}
 pointer =
-    { value = "pointer", cursor = Compatible }
+    Value "pointer"
 
 
 {-| -}
 progress : Cursor {}
 progress =
-    { value = "progress", cursor = Compatible }
+    Value "progress"
 
 
 {-| -}
 wait : Cursor {}
 wait =
-    { value = "wait", cursor = Compatible }
+    Value "wait"
 
 
 {-| -}
 cell : Cursor {}
 cell =
-    { value = "cell", cursor = Compatible }
+    Value "cell"
 
 
 {-| -}
 text_ : Cursor {}
 text_ =
-    { value = "text", cursor = Compatible }
+    Value "text"
 
 
 {-| -}
 verticalText : Cursor {}
 verticalText =
-    { value = "vertical-text", cursor = Compatible }
+    Value "vertical-text"
 
 
 {-| -}
 cursorAlias : Cursor {}
 cursorAlias =
-    { value = "alias", cursor = Compatible }
+    Value "alias"
 
 
 {-| -}
 copy : Cursor {}
 copy =
-    { value = "copy", cursor = Compatible }
+    Value "copy"
 
 
 {-| -}
 move : Cursor {}
 move =
-    { value = "move", cursor = Compatible }
+    Value "move"
 
 
 {-| -}
 noDrop : Cursor {}
 noDrop =
-    { value = "no-drop", cursor = Compatible }
+    Value "no-drop"
 
 
 {-| -}
 notAllowed : Cursor {}
 notAllowed =
-    { value = "not-allowed", cursor = Compatible }
+    Value "not-allowed"
 
 
 {-| -}
 eResize : Cursor {}
 eResize =
-    { value = "e-resize", cursor = Compatible }
+    Value "e-resize"
 
 
 {-| -}
 nResize : Cursor {}
 nResize =
-    { value = "n-resize", cursor = Compatible }
+    Value "n-resize"
 
 
 {-| -}
 neResize : Cursor {}
 neResize =
-    { value = "ne-resize", cursor = Compatible }
+    Value "ne-resize"
 
 
 {-| -}
 nwResize : Cursor {}
 nwResize =
-    { value = "nw-resize", cursor = Compatible }
+    Value "nw-resize"
 
 
 {-| -}
 sResize : Cursor {}
 sResize =
-    { value = "s-resize", cursor = Compatible }
+    Value "s-resize"
 
 
 {-| -}
 seResize : Cursor {}
 seResize =
-    { value = "se-resize", cursor = Compatible }
+    Value "se-resize"
 
 
 {-| -}
 swResize : Cursor {}
 swResize =
-    { value = "sw-resize", cursor = Compatible }
+    Value "sw-resize"
 
 
 {-| -}
 wResize : Cursor {}
 wResize =
-    { value = "w-resize", cursor = Compatible }
+    Value "w-resize"
 
 
 {-| -}
 ewResize : Cursor {}
 ewResize =
-    { value = "ew-resize", cursor = Compatible }
+    Value "ew-resize"
 
 
 {-| -}
 nsResize : Cursor {}
 nsResize =
-    { value = "ns-resize", cursor = Compatible }
+    Value "ns-resize"
 
 
 {-| -}
 neswResize : Cursor {}
 neswResize =
-    { value = "nesw-resize", cursor = Compatible }
+    Value "nesw-resize"
 
 
 {-| -}
 nwseResize : Cursor {}
 nwseResize =
-    { value = "nwse-resize", cursor = Compatible }
+    Value "nwse-resize"
 
 
 {-| -}
 colResize : Cursor {}
 colResize =
-    { value = "col-resize", cursor = Compatible }
+    Value "col-resize"
 
 
 {-| -}
 rowResize : Cursor {}
 rowResize =
-    { value = "row-resize", cursor = Compatible }
+    Value "row-resize"
 
 
 {-| -}
 allScroll : Cursor {}
 allScroll =
-    { value = "all-scroll", cursor = Compatible }
+    Value "all-scroll"
 
 
 {-| -}
 zoomIn : Cursor {}
 zoomIn =
-    { value = "zoom-in", cursor = Compatible }
+    Value "zoom-in"
 
 
 {-| -}
 zoomOut : Cursor {}
 zoomOut =
-    { value = "zoom-out", cursor = Compatible }
+    Value "zoom-out"
 
 
 {-| -}
 grab : Cursor {}
 grab =
-    { value = "grab", cursor = Compatible }
+    Value "grab"
 
 
 {-| -}
 grabbing : Cursor {}
 grabbing =
-    { value = "grabbing", cursor = Compatible }
+    Value "grabbing"
 
 
 
@@ -7680,9 +7122,7 @@ textDecorationStyle =
 -}
 pre : WhiteSpace {}
 pre =
-    { value = "pre"
-    , whiteSpace = Compatible
-    }
+    Value "pre"
 
 
 {-| The `pre-wrap` [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) value.
@@ -7692,9 +7132,7 @@ pre =
 -}
 preWrap : WhiteSpace {}
 preWrap =
-    { value = "pre-wrap"
-    , whiteSpace = Compatible
-    }
+    Value "pre-wrap"
 
 
 {-| The `pre-line` [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) value.
@@ -7704,9 +7142,7 @@ preWrap =
 -}
 preLine : WhiteSpace {}
 preLine =
-    { value = "pre-line"
-    , whiteSpace = Compatible
-    }
+    Value "pre-line"
 
 
 {-| Sets [`animation-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name)
@@ -8241,17 +7677,20 @@ numericalPercentageToString value =
 valuesOrNone : List (Value compatible) -> Value {}
 valuesOrNone list =
     if List.isEmpty list then
-        { value = "none" }
+        Value "none"
     else
-        { value = String.join " " (List.map .value list) }
+        list
+            |> List.map (\(Value value) -> value)
+            |> String.join " "
+            |> Value
 
 
 stringsToValue : List String -> Value {}
 stringsToValue list =
     if List.isEmpty list then
-        { value = "none" }
+        Value "none"
     else
-        { value = String.join ", " (List.map (\s -> s) list) }
+        Value (String.join ", " list)
 
 
 {-| Sets [`z-index`](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
@@ -8275,72 +7714,56 @@ zIndex =
 -}
 panX : TouchAction {}
 panX =
-    { value = "pan-x"
-    , touchAction = Compatible
-    }
+    Value "pan-x"
 
 
 {-| The `pan-left` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 panLeft : TouchAction {}
 panLeft =
-    { value = "pan-left"
-    , touchAction = Compatible
-    }
+    Value "pan-left"
 
 
 {-| The `pan-right` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 panRight : TouchAction {}
 panRight =
-    { value = "pan-right"
-    , touchAction = Compatible
-    }
+    Value "pan-right"
 
 
 {-| The `pan-y` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 panY : TouchAction {}
 panY =
-    { value = "pan-y"
-    , touchAction = Compatible
-    }
+    Value "pan-y"
 
 
 {-| The `pan-up` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 panUp : TouchAction {}
 panUp =
-    { value = "pan-up"
-    , touchAction = Compatible
-    }
+    Value "pan-up"
 
 
 {-| The `pan-down` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 panDown : TouchAction {}
 panDown =
-    { value = "pan-down"
-    , touchAction = Compatible
-    }
+    Value "pan-down"
 
 
 {-| The `pinch-zoom` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 pinchZoom : TouchAction {}
 pinchZoom =
-    { value = "pinch-zoom"
-    , touchAction = Compatible
-    }
+    Value "pinch-zoom"
 
 
 {-| The `manipulation` value for the [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
 -}
 manipulation : TouchAction {}
 manipulation =
-    { value = "manipulation"
-    , touchAction = Compatible
-    }
+    Value "manipulation"
 
 
 {-| Sets [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property.
@@ -8391,7 +7814,7 @@ pointerEvents =
 -}
 visiblePainted : PointerEvents {}
 visiblePainted =
-    { value = "visiblePainted", pointerEvents = Compatible }
+    Value "visiblePainted"
 
 
 {-| A `visibleFill` [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) value.
@@ -8401,7 +7824,7 @@ visiblePainted =
 -}
 visibleFill : PointerEvents {}
 visibleFill =
-    { value = "visibleFill", pointerEvents = Compatible }
+    Value "visibleFill"
 
 
 {-| A `visibleStroke` [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) value.
@@ -8411,7 +7834,7 @@ visibleFill =
 -}
 visibleStroke : PointerEvents {}
 visibleStroke =
-    { value = "visibleStroke", pointerEvents = Compatible }
+    Value "visibleStroke"
 
 
 {-| A `painted` [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) value.
@@ -8421,7 +7844,7 @@ visibleStroke =
 -}
 painted : PointerEvents {}
 painted =
-    { value = "painted", pointerEvents = Compatible }
+    Value "painted"
 
 
 {-| `property-events: fill`. This works around the fact that
@@ -8447,4 +7870,4 @@ pointerEventsAll =
 -}
 stroke : PointerEvents {}
 stroke =
-    { value = "stroke", pointerEvents = Compatible }
+    Value "stroke"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3875,7 +3875,6 @@ none :
         , textDecorationLine : Compatible
         , transform : Compatible
         , backgroundImage : Compatible
-        , value : String
         , textTransform : Compatible
         , touchAction : Compatible
         , updateFrequency : Compatible
@@ -3900,7 +3899,6 @@ auto :
         , alignItemsOrAuto : Compatible
         , justifyContentOrAuto : Compatible
         , cursor : Compatible
-        , value : String
         , lengthOrAutoOrCoverOrContain : Compatible
         , intOrAuto : Compatible
         , pointerEvents : Compatible

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1428,11 +1428,7 @@ type alias LengthOrAutoOrCoverOrContain compatible =
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/length>
 -}
 type alias Length compatible units =
-    Value
-        { compatible
-            | units : units
-            , length : Compatible
-        }
+    Value { compatible | units : units, length : Compatible }
 
 
 {-| <https://developer.mozilla.org/en/docs/Web/CSS/calc>
@@ -1923,7 +1919,7 @@ luminosity =
 
 {-| The `padding-box` [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) value.
 -}
-paddingBox : BackgroundClip compatible
+paddingBox : BackgroundClip {}
 paddingBox =
     Value "padding-box"
 
@@ -1937,14 +1933,14 @@ url urlValue =
 
 {-| The `cover` [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) value.
 -}
-cover : Value { lengthOrAutoOrCoverOrContain : Compatible }
+cover : LengthOrAutoOrCoverOrContain {}
 cover =
     Value "cover"
 
 
 {-| The `contain` [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) value.
 -}
-contain : Value { lengthOrAutoOrCoverOrContain : Compatible }
+contain : LengthOrAutoOrCoverOrContain {}
 contain =
     Value "contain"
 
@@ -4048,8 +4044,8 @@ float fn =
 
 -}
 textDecorationColor : Color -> Style
-textDecorationColor (Value color) =
-    property "text-decoration-color" color
+textDecorationColor =
+    prop1 "text-decoration-color"
 
 
 {-| Sets ['text-emphasis-color'](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color)
@@ -4058,8 +4054,8 @@ textDecorationColor (Value color) =
 
 -}
 textEmphasisColor : Color -> Style
-textEmphasisColor (Value color) =
-    property "text-emphasis-color" color
+textEmphasisColor =
+    prop1 "text-emphasis-color"
 
 
 {-| Sets [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last).
@@ -5638,8 +5634,8 @@ borderImageWidth4 =
 
 -}
 borderBlockStartColor : Color -> Style
-borderBlockStartColor (Value color) =
-    property "border-block-start-color" color
+borderBlockStartColor =
+    prop1 "border-block-start-color"
 
 
 {-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color)
@@ -5648,8 +5644,8 @@ borderBlockStartColor (Value color) =
 
 -}
 borderBottomColor : Color -> Style
-borderBottomColor (Value color) =
-    property "border-bottom-color" color
+borderBottomColor =
+    prop1 "border-bottom-color"
 
 
 {-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)
@@ -5658,8 +5654,8 @@ borderBottomColor (Value color) =
 
 -}
 borderInlineStartColor : Color -> Style
-borderInlineStartColor (Value color) =
-    property "border-inline-start-color" color
+borderInlineStartColor =
+    prop1 "border-inline-start-color"
 
 
 {-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color)
@@ -5668,8 +5664,8 @@ borderInlineStartColor (Value color) =
 
 -}
 borderInlineEndColor : Color -> Style
-borderInlineEndColor (Value color) =
-    property "border-inline-end-color" color
+borderInlineEndColor =
+    prop1 "border-inline-end-color"
 
 
 {-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color)
@@ -5678,8 +5674,8 @@ borderInlineEndColor (Value color) =
 
 -}
 borderLeftColor : Color -> Style
-borderLeftColor (Value color) =
-    property "border-left-color" color
+borderLeftColor =
+    prop1 "border-left-color"
 
 
 {-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color)
@@ -5688,8 +5684,8 @@ borderLeftColor (Value color) =
 
 -}
 borderRightColor : Color -> Style
-borderRightColor (Value color) =
-    property "border-right-color" color
+borderRightColor =
+    prop1 "border-right-color"
 
 
 {-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color)
@@ -5698,8 +5694,8 @@ borderRightColor (Value color) =
 
 -}
 borderTopColor : Color -> Style
-borderTopColor (Value color) =
-    property "border-top-color" color
+borderTopColor =
+    prop1 "border-top-color"
 
 
 {-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color)
@@ -5708,8 +5704,8 @@ borderTopColor (Value color) =
 
 -}
 borderBlockEndColor : Color -> Style
-borderBlockEndColor (Value color) =
-    property "border-block-end-color" color
+borderBlockEndColor =
+    prop1 "border-block-end-color"
 
 
 {-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style)
@@ -6097,8 +6093,8 @@ borderSpacing2 =
 
 -}
 borderColor : Color -> Style
-borderColor (Value color) =
-    property "border-color" color
+borderColor =
+    prop1 "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -6177,9 +6173,9 @@ outline3 =
     outlineColor (hsla 120 0.5 0.5 0.5)
 
 -}
-outlineColor : ColorValue compatibleE -> Style
-outlineColor (Value color) =
-    property "outline-color" color
+outlineColor : ColorValue compatible -> Style
+outlineColor =
+    prop1 "outline-color"
 
 
 {-| Sets [`outline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width)
@@ -6268,8 +6264,8 @@ whiteSpace =
 
 {-| -}
 backgroundColor : Color -> Style
-backgroundColor (Value color) =
-    property "background-color" color
+backgroundColor =
+    prop1 "background-color"
 
 
 {-| Sets ['background-repeat'](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
@@ -6388,8 +6384,8 @@ backgroundSize2 =
 
 {-| -}
 color : ColorValue compatible -> Style
-color (Value color) =
-    property "color" color
+color =
+    prop1 "color"
 
 
 
@@ -6466,8 +6462,8 @@ fontFamilies =
 
 -}
 fontFeatureSettings : FeatureTagValue compatible -> Style
-fontFeatureSettings (Value value) =
-    property "font-feature-settings" value
+fontFeatureSettings =
+    prop1 "font-feature-settings"
 
 
 {-| Sets [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings)
@@ -6511,8 +6507,8 @@ fontStyle =
 
 -}
 fontWeight : FontWeight compatible -> Style
-fontWeight (Value value) =
-    property "font-weight" value
+fontWeight =
+    prop1 "font-weight"
 
 
 {-| Sets [`font-variant`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant)
@@ -7487,7 +7483,7 @@ numericalPercentageToString value =
     value |> (*) 100 |> numberToString |> flip (++) "%"
 
 
-valuesOrNone : List (Value compatible) -> Value compatible
+valuesOrNone : List (Value compatible) -> Value {}
 valuesOrNone list =
     if List.isEmpty list then
         Value "none"
@@ -7498,7 +7494,7 @@ valuesOrNone list =
             |> Value
 
 
-stringsToValue : List String -> Value compatible
+stringsToValue : List String -> Value {}
 stringsToValue list =
     if List.isEmpty list then
         Value "none"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1040,7 +1040,7 @@ deprecated or discouraged.
 
 import Css.Helpers exposing (identifierToString, toCssIdentifier)
 import Css.Preprocess as Preprocess exposing (Style, unwrapSnippet)
-import Css.Structure as Structure exposing (..)
+import Css.Structure as Structure exposing (Property)
 import Hex
 import Regex exposing (regex)
 import String
@@ -1809,12 +1809,7 @@ a `visible` [`visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/visi
 a `visible` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values), or
 a `visible` [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) value.
 -}
-visible :
-    Value
-        { overflow : Compatible
-        , visibility : Compatible
-        , pointerEvents : Compatible
-        }
+visible : Value { overflow : Compatible, visibility : Compatible, pointerEvents : Compatible }
 visible =
     Value "visible"
 
@@ -1963,7 +1958,7 @@ luminosity =
 
 {-| The `padding-box` [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) value.
 -}
-paddingBox : BackgroundClip {}
+paddingBox : BackgroundClip compatible
 paddingBox =
     Value "padding-box"
 
@@ -1995,7 +1990,7 @@ This can also represent a `hidden` [border style](https://developer.mozilla.org/
 as well as a `hidden` [`visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#Values).
 
 -}
-hidden : Overflow (BorderStyle (Visibility {}))
+hidden : Value { overflow : Compatible, borderStyle : Compatible, visibility : Compatible }
 hidden =
     Value "hidden"
 
@@ -2285,28 +2280,28 @@ wavy =
 
 {-| A `dotted` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-dotted : BorderStyle (TextDecorationStyle {})
+dotted : Value { borderStyle : Compatible, textDecorationStyle : Compatible }
 dotted =
     Value "dotted"
 
 
 {-| A `dashed` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-dashed : BorderStyle (TextDecorationStyle {})
+dashed : Value { borderStyle : Compatible, textDecorationStyle : Compatible }
 dashed =
     Value "dashed"
 
 
 {-| A `solid` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-solid : BorderStyle (TextDecorationStyle {})
+solid : Value { borderStyle : Compatible, textDecorationStyle : Compatible }
 solid =
     Value "solid"
 
 
 {-| A `double` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-double : BorderStyle (TextDecorationStyle {})
+double : Value { borderStyle : Compatible, textDecorationStyle : Compatible }
 double =
     Value "double"
 
@@ -2353,7 +2348,7 @@ separate =
 {-| A `collapse` [border-collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse#Values).
 This can also represent a `collapse` [`visibility`](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#Values).
 -}
-collapse : BorderCollapse (Visibility {})
+collapse : Value { borderCollapse : Compatible, visibility : Compatible }
 collapse =
     Value "collapse"
 
@@ -2510,7 +2505,7 @@ rem value =
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
 -}
 type alias Vh =
-    ExplicitLength { vk : Compatible }
+    ExplicitLength { vh : Compatible }
 
 
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
@@ -2643,25 +2638,35 @@ pc value =
 {-| A unitless integer. Useful with properties like [`borderImageOutset`](#borderImageOutset)
 which accept either length units or unitless numbers for some properties.
 -}
-int : Int -> IntOrAuto (LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (FontWeight (Number { units : UnitlessInteger }))))
+int : Int -> UnitlessInteger
 int val =
     Value (numberToString val)
 
 
 type alias UnitlessInteger =
-    { integer : Compatible }
+    Value
+        { intOrAuto : Compatible
+        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , lengthOrNumber : Compatible
+        , fontWeight : Compatible
+        , number : Compatible
+        }
 
 
 {-| A unitless number. Useful with properties like [`flexGrow`](#flexGrow)
 which accept unitless numbers.
 -}
-num : Float -> LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (Number { units : UnitlessFloat }))
+num : Float -> UnitlessFloat
 num val =
     Value (numberToString val)
 
 
 type alias UnitlessFloat =
-    { float : Compatible }
+    Value
+        { lengthOrNumberOrAutoOrNoneOrContent : Compatible
+        , lengthOrNumber : Compatible
+        , number : Compatible
+        }
 
 
 lengthForOverloadedProperty : ExplicitLength IncompatibleUnits
@@ -2678,35 +2683,42 @@ type alias IncompatibleUnits =
 {- ANGLES -}
 
 
-angleConverter : String -> number -> AngleOrDirection (Angle {})
+type alias AngleWithDirection =
+    Value
+        { angleOrDirection : Compatible
+        , angle : Compatible
+        }
+
+
+angleConverter : String -> number -> AngleWithDirection
 angleConverter suffix num =
     Value (numberToString num ++ suffix)
 
 
 {-| [`deg`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#deg) units.
 -}
-deg : number -> AngleOrDirection (Angle {})
+deg : number -> AngleWithDirection
 deg =
     angleConverter "deg"
 
 
 {-| [`grad`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#grad) units.
 -}
-grad : number -> AngleOrDirection (Angle {})
+grad : number -> AngleWithDirection
 grad =
     angleConverter "grad"
 
 
 {-| [`rad`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#rad) units.
 -}
-rad : number -> AngleOrDirection (Angle {})
+rad : number -> AngleWithDirection
 rad =
     angleConverter "rad"
 
 
 {-| [`turn`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#tr) units.
 -}
-turn : number -> AngleOrDirection (Angle {})
+turn : number -> AngleWithDirection
 turn =
     angleConverter "turn"
 
@@ -3008,7 +3020,7 @@ fillBox =
 {-| The `content-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
 Can also be used as `content-box` value for the [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) property.
 -}
-contentBox : BoxSizing (BackgroundClip {})
+contentBox : Value { boxSizing : Compatible, backgroundClip : Compatible }
 contentBox =
     Value "content-box"
 
@@ -3016,7 +3028,7 @@ contentBox =
 {-| The `border-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
 Can also be used as `border-box` value for the [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) property.
 -}
-borderBox : BoxSizing (BackgroundClip {})
+borderBox : Value { boxSizing : Compatible, backgroundClip : Compatible }
 borderBox =
     Value "border-box"
 
@@ -3077,14 +3089,21 @@ listStylePosition =
     prop1 "list-style-position"
 
 
+type alias ListStyleWithPosition =
+    Value
+        { listStylePosition : Compatible
+        , listStyleTypeOrPositionOrImage : Compatible
+        }
+
+
 {-| -}
-inside : ListStyle (ListStylePosition {})
+inside : ListStyleWithPosition
 inside =
     Value "inside"
 
 
 {-| -}
-outside : ListStyle (ListStylePosition {})
+outside : ListStyleWithPosition
 outside =
     Value "outside"
 
@@ -3100,182 +3119,189 @@ listStyleType =
     prop1 "list-style-type"
 
 
+type alias ListStyleWithType =
+    Value
+        { listStyleType : Compatible
+        , listStyleTypeOrPositionOrImage : Compatible
+        }
+
+
 {-| -}
-disc : ListStyle (ListStyleType {})
+disc : ListStyleWithType
 disc =
     Value "disc"
 
 
 {-| -}
-circle : ListStyle (ListStyleType {})
+circle : ListStyleWithType
 circle =
     Value "circle"
 
 
 {-| -}
-square : ListStyle (ListStyleType {})
+square : ListStyleWithType
 square =
     Value "square"
 
 
 {-| -}
-decimal : ListStyle (ListStyleType {})
+decimal : ListStyleWithType
 decimal =
     Value "decimal"
 
 
 {-| -}
-decimalLeadingZero : ListStyle (ListStyleType {})
+decimalLeadingZero : ListStyleWithType
 decimalLeadingZero =
     Value "decimal-leading-zero"
 
 
 {-| -}
-lowerRoman : ListStyle (ListStyleType {})
+lowerRoman : ListStyleWithType
 lowerRoman =
     Value "lower-roman"
 
 
 {-| -}
-upperRoman : ListStyle (ListStyleType {})
+upperRoman : ListStyleWithType
 upperRoman =
     Value "upper-roman"
 
 
 {-| -}
-lowerGreek : ListStyle (ListStyleType {})
+lowerGreek : ListStyleWithType
 lowerGreek =
     Value "lower-greek"
 
 
 {-| -}
-upperGreek : ListStyle (ListStyleType {})
+upperGreek : ListStyleWithType
 upperGreek =
     Value "upper-greek"
 
 
 {-| -}
-lowerAlpha : ListStyle (ListStyleType {})
+lowerAlpha : ListStyleWithType
 lowerAlpha =
     Value "lower-alpha"
 
 
 {-| -}
-upperAlpha : ListStyle (ListStyleType {})
+upperAlpha : ListStyleWithType
 upperAlpha =
     Value "upper-alpha"
 
 
 {-| -}
-lowerLatin : ListStyle (ListStyleType {})
+lowerLatin : ListStyleWithType
 lowerLatin =
     Value "lower-latin"
 
 
 {-| -}
-upperLatin : ListStyle (ListStyleType {})
+upperLatin : ListStyleWithType
 upperLatin =
     Value "upper-latin"
 
 
 {-| -}
-arabicIndic : ListStyle (ListStyleType {})
+arabicIndic : ListStyleWithType
 arabicIndic =
     Value "arabic-indic"
 
 
 {-| -}
-armenian : ListStyle (ListStyleType {})
+armenian : ListStyleWithType
 armenian =
     Value "armenian"
 
 
 {-| -}
-bengali : ListStyle (ListStyleType {})
+bengali : ListStyleWithType
 bengali =
     Value "bengali"
 
 
 {-| -}
-cjkEarthlyBranch : ListStyle (ListStyleType {})
+cjkEarthlyBranch : ListStyleWithType
 cjkEarthlyBranch =
     Value "cjk-earthly-branch"
 
 
 {-| -}
-cjkHeavenlyStem : ListStyle (ListStyleType {})
+cjkHeavenlyStem : ListStyleWithType
 cjkHeavenlyStem =
     Value "cjk-heavenly-stem"
 
 
 {-| -}
-devanagari : ListStyle (ListStyleType {})
+devanagari : ListStyleWithType
 devanagari =
     Value "devanagari"
 
 
 {-| -}
-georgian : ListStyle (ListStyleType {})
+georgian : ListStyleWithType
 georgian =
     Value "georgian"
 
 
 {-| -}
-gujarati : ListStyle (ListStyleType {})
+gujarati : ListStyleWithType
 gujarati =
     Value "gujarati"
 
 
 {-| -}
-gurmukhi : ListStyle (ListStyleType {})
+gurmukhi : ListStyleWithType
 gurmukhi =
     Value "gurmukhi"
 
 
 {-| -}
-kannada : ListStyle (ListStyleType {})
+kannada : ListStyleWithType
 kannada =
     Value "kannada"
 
 
 {-| -}
-khmer : ListStyle (ListStyleType {})
+khmer : ListStyleWithType
 khmer =
     Value "khmer"
 
 
 {-| -}
-lao : ListStyle (ListStyleType {})
+lao : ListStyleWithType
 lao =
     Value "lao"
 
 
 {-| -}
-malayalam : ListStyle (ListStyleType {})
+malayalam : ListStyleWithType
 malayalam =
     Value "malayalam"
 
 
 {-| -}
-myanmar : ListStyle (ListStyleType {})
+myanmar : ListStyleWithType
 myanmar =
     Value "myanmar"
 
 
 {-| -}
-oriya : ListStyle (ListStyleType {})
+oriya : ListStyleWithType
 oriya =
     Value "oriya"
 
 
 {-| -}
-telugu : ListStyle (ListStyleType {})
+telugu : ListStyleWithType
 telugu =
     Value "telugu"
 
 
 {-| -}
-thai : ListStyle (ListStyleType {})
+thai : ListStyleWithType
 thai =
     Value "thai"
 
@@ -3460,7 +3486,7 @@ order =
 {-| The [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values) value for the
 flex-basis property.
 -}
-content : LengthOrNumberOrAutoOrNoneOrContent (FlexBasis {})
+content : Value { flexBasis : Compatible, lengthOrNumberOrAutoOrNoneOrContent : Compatible }
 content =
     Value "content"
 
@@ -3468,7 +3494,7 @@ content =
 {-| The[`wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values) value for the
 flex-wrap property.
 -}
-wrap : FlexDirectionOrWrap (FlexWrap {})
+wrap : Value { flexWrap : Compatible, flexDirectionOrWrap : Compatible }
 wrap =
     Value "wrap"
 
@@ -3476,7 +3502,7 @@ wrap =
 {-| The[`wrap-reverse`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values) value for the
 flex-wrap property.
 -}
-wrapReverse : FlexDirectionOrWrap (FlexWrap {})
+wrapReverse : Value { flexWrap : Compatible, flexDirectionOrWrap : Compatible }
 wrapReverse =
     Value "wrap-reverse"
 
@@ -3526,7 +3552,7 @@ stretch =
 {-| The[`row`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
 flex-direction property.
 -}
-row : FlexDirectionOrWrap (FlexDirection {})
+row : Value { flexDirection : Compatible, flexDirectionOrWrap : Compatible }
 row =
     Value "row"
 
@@ -3534,7 +3560,7 @@ row =
 {-| The[`row-reverse`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
 flex-direction property.
 -}
-rowReverse : FlexDirectionOrWrap (FlexDirection {})
+rowReverse : Value { flexDirection : Compatible, flexDirectionOrWrap : Compatible }
 rowReverse =
     Value "row-reverse"
 
@@ -3542,7 +3568,7 @@ rowReverse =
 {-| The[`column`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
 flex-direction property.
 -}
-column : FlexDirectionOrWrap (FlexDirection {})
+column : Value { flexDirection : Compatible, flexDirectionOrWrap : Compatible }
 column =
     Value "column"
 
@@ -3550,7 +3576,7 @@ column =
 {-| The[`column-reverse`](<https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction> #Values) value for the
 flex-direction property.
 -}
-columnReverse : FlexDirectionOrWrap (FlexDirection {})
+columnReverse : Value { flexDirection : Compatible, flexDirectionOrWrap : Compatible }
 columnReverse =
     Value "column-reverse"
 
@@ -3656,7 +3682,7 @@ linearGradient :
     ColorStop compatible unit
     -> ColorStop compatible unit
     -> List (ColorStop compatible unit)
-    -> BackgroundImage (ListStyle {})
+    -> Value { backgroundImage : Compatible, listStyleTypeOrPositionOrImage : Compatible }
 linearGradient stop1 stop2 stops =
     -- TODO we should make this more permissive, e.g. compatibleA/compatibleB/compatibleC/compatibleD
     -- the only reason it isn't is that we happen to be using collectStops like this.
@@ -3680,7 +3706,7 @@ linearGradient2 :
     -> ColorStop compatibleB unit
     -> ColorStop compatibleB unit
     -> List (ColorStop compatibleB unit)
-    -> BackgroundImage (ListStyle {})
+    -> Value { backgroundImage : Compatible, listStyleTypeOrPositionOrImage : Compatible }
 linearGradient2 (Value dir) stop1 stop2 stops =
     stop1
         :: stop2
@@ -3940,7 +3966,12 @@ auto =
 
 
 {-| -}
-noWrap : WhiteSpace (FlexDirectionOrWrap (FlexWrap {}))
+noWrap :
+    Value
+        { whiteSpace : Compatible
+        , flexWrap : Compatible
+        , flexDirectionOrWrap : Compatible
+        }
 noWrap =
     Value "nowrap"
 
@@ -6487,7 +6518,7 @@ fontFamilies =
     fontFeatureSettings (featureTag2 "swsh" 2)
 
 -}
-fontFeatureSettings : FeatureTagValue a -> Style
+fontFeatureSettings : FeatureTagValue compatible -> Style
 fontFeatureSettings (Value value) =
     property "font-feature-settings" value
 
@@ -6497,7 +6528,7 @@ fontFeatureSettings (Value value) =
     fontFeatureSettingsList [featureTag "c2sc", featureTag "smcp"]
 
 -}
-fontFeatureSettingsList : List (FeatureTagValue a) -> Style
+fontFeatureSettingsList : List (FeatureTagValue compatible) -> Style
 fontFeatureSettingsList featureTagValues =
     featureTagValues
         |> List.map (\(Value value) -> value)
@@ -6511,7 +6542,7 @@ fontFeatureSettingsList featureTagValues =
     fontSize  (px 12)
 
 -}
-fontSize : FontSize a -> Style
+fontSize : FontSize compatible -> Style
 fontSize =
     prop1 "font-size"
 
@@ -6521,7 +6552,7 @@ fontSize =
     fontStyle  italic
 
 -}
-fontStyle : FontStyle a -> Style
+fontStyle : FontStyle compatible -> Style
 fontStyle =
     prop1 "font-style"
 
@@ -6532,7 +6563,7 @@ fontStyle =
     fontWeight  (int 300)
 
 -}
-fontWeight : FontWeight a -> Style
+fontWeight : FontWeight compatible -> Style
 fontWeight (Value value) =
     property "font-weight" value
 
@@ -6545,7 +6576,7 @@ fontWeight (Value value) =
     fontVariants  [ oldstyleNums tabularNums stackedFractions ordinal slashedZero ]
 
 -}
-fontVariant : FontVariant a -> Style
+fontVariant : FontVariant compatible -> Style
 fontVariant =
     prop1 "font-variant"
 
@@ -6563,19 +6594,19 @@ fontVariant3 =
 
 
 {-| -}
-fontVariantLigatures : FontVariantLigatures a -> Style
+fontVariantLigatures : FontVariantLigatures compatible -> Style
 fontVariantLigatures =
     prop1 "font-variant-ligatures"
 
 
 {-| -}
-fontVariantCaps : FontVariantCaps a -> Style
+fontVariantCaps : FontVariantCaps compatible -> Style
 fontVariantCaps =
     prop1 "font-variant-caps"
 
 
 {-| -}
-fontVariantNumeric : FontVariantNumeric a -> Style
+fontVariantNumeric : FontVariantNumeric compatible -> Style
 fontVariantNumeric =
     prop1 "font-variant-numeric"
 
@@ -6835,7 +6866,7 @@ You can specify multiple line decorations with `textDecorations`.
     textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 
 -}
-textDecoration : TextDecorationLine a -> Style
+textDecoration : TextDecorationLine compatible -> Style
 textDecoration =
     prop1 "text-decoration"
 
@@ -7509,7 +7540,7 @@ numericalPercentageToString value =
     value |> (*) 100 |> numberToString |> flip (++) "%"
 
 
-valuesOrNone : List (Value compatible) -> Value {}
+valuesOrNone : List (Value compatible) -> Value compatible
 valuesOrNone list =
     if List.isEmpty list then
         Value "none"
@@ -7520,7 +7551,7 @@ valuesOrNone list =
             |> Value
 
 
-stringsToValue : List String -> Value {}
+stringsToValue : List String -> Value compatible
 stringsToValue list =
     if List.isEmpty list then
         Value "none"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1040,7 +1040,7 @@ deprecated or discouraged.
 
 import Css.Helpers exposing (identifierToString, toCssIdentifier)
 import Css.Preprocess as Preprocess exposing (Style, unwrapSnippet)
-import Css.Structure as Structure exposing (Property)
+import Css.Structure as Structure exposing (Property, Value(Value))
 import Hex
 import Regex exposing (regex)
 import String
@@ -1126,8 +1126,8 @@ type alias Compatible =
 
 
 {-| -}
-type Value compatible
-    = Value String
+type alias Value compatible =
+    Structure.Value compatible
 
 
 {-| -}
@@ -1137,7 +1137,7 @@ type alias All compatible =
 
 {-| -}
 type alias Number compatible =
-    Value { compatible | number : Compatible }
+    Structure.Number compatible
 
 
 {-| -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1041,7 +1041,6 @@ deprecated or discouraged.
 import Css.Helpers exposing (identifierToString)
 import Css.Preprocess as Preprocess
 import Css.Structure as Structure exposing (Property, Value(Value))
-import Hex
 import String
 
 
@@ -2090,27 +2089,6 @@ hex str =
         Value str
     else
         Value ("#" ++ str)
-
-
-hexaToRgba : String -> ( Char, Char ) -> ( Char, Char ) -> ( Char, Char ) -> ( Char, Char ) -> Result String Color
-hexaToRgba str ( r1, r2 ) ( g1, g2 ) ( b1, b2 ) ( a1, a2 ) =
-    let
-        toResult =
-            String.fromList >> String.toLower >> Hex.fromString
-
-        results =
-            ( toResult [ r1, r2 ]
-            , toResult [ g1, g2 ]
-            , toResult [ b1, b2 ]
-            , toResult [ a1, a2 ]
-            )
-    in
-    case results of
-        ( Ok red, Ok green, Ok blue, Ok alpha ) ->
-            Ok (rgba red green blue (toFloat alpha / 255))
-
-        _ ->
-            Err ("Invalid hex color: `" ++ str ++ "`")
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -5,6 +5,7 @@ module Css
         , Angle
         , AngleOrDirection
         , BackgroundAttachment
+        , BackgroundBlendMode
         , BackgroundClip
         , BackgroundImage
         , BackgroundOrigin
@@ -1020,7 +1021,7 @@ functions let you define custom properties and selectors, respectively.
 @docs listStyle, listStyle2, listStyle3
 @docs linearGradient, linearGradient2, stop, stop2, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
-@docs AlignItems, All, Angle, AngleOrDirection, BackgroundAttachment, BackgroundClip, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatShorthand, BasicProperty, BorderCollapse, BorderStyle, BoxSizing, Calc, CalcExpression, Cursor, Directionality, Display, ExplicitLength, FeatureTagValue, FlexBasis, FlexDirection, FlexDirectionOrWrap, FlexWrap, FontFamily, FontStyle, FontStyleOrFeatureTagValue, FontVariant, FontVariantCaps, FontVariantLigatures, FontVariantNumeric, FontWeight, ImportType, IncompatibleUnits, JustifyContent, LengthOrAuto, LengthOrAutoOrCoverOrContain, LengthOrMinMaxDimension, LengthOrNone, LengthOrNoneOrMinMaxDimension, LengthOrNumber, LengthOrNumberOrAutoOrNoneOrContent, ListStyle, ListStylePosition, ListStyleType, MinMaxDimension, None, Number, Outline, Overflow, Visibility, Position, Resize, TableLayout, TextDecorationLine, TextDecorationStyle, TextIndent, TextOrientation, TextOverflow, TextRendering, TextTransform, TouchAction, Transform, TransformBox, TransformStyle, Value, VerticalAlign, WhiteSpace, Wrap, pre, preLine, preWrap
+@docs AlignItems, All, Angle, AngleOrDirection, BackgroundAttachment, BackgroundBlendMode, BackgroundClip, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatShorthand, BasicProperty, BorderCollapse, BorderStyle, BoxSizing, Calc, CalcExpression, Cursor, Directionality, Display, ExplicitLength, FeatureTagValue, FlexBasis, FlexDirection, FlexDirectionOrWrap, FlexWrap, FontFamily, FontStyle, FontStyleOrFeatureTagValue, FontVariant, FontVariantCaps, FontVariantLigatures, FontVariantNumeric, FontWeight, ImportType, IncompatibleUnits, JustifyContent, LengthOrAuto, LengthOrAutoOrCoverOrContain, LengthOrMinMaxDimension, LengthOrNone, LengthOrNoneOrMinMaxDimension, LengthOrNumber, LengthOrNumberOrAutoOrNoneOrContent, ListStyle, ListStylePosition, ListStyleType, MinMaxDimension, None, Number, Outline, Overflow, Visibility, Position, Resize, TableLayout, TextDecorationLine, TextDecorationStyle, TextIndent, TextOrientation, TextOverflow, TextRendering, TextTransform, TouchAction, Transform, TransformBox, TransformStyle, Value, VerticalAlign, WhiteSpace, Wrap, pre, preLine, preWrap
 
 
 # Types
@@ -1387,6 +1388,17 @@ type alias BackgroundAttachment compatible =
 -}
 type alias BackgroundPosition compatible =
     Value { compatible | backgroundPosition : Compatible }
+
+
+{-| Because `color` is both a common propertie and common value
+in CSS (e.g. `color: red` with and `background-blend-mode: color`),
+we implement it as a property (for the `color: red` case) and allow it to
+be used as a value as well. When being used as a value, we call it, expect
+that it will return the desired String as its key, and use that as our value.
+(See `getOverloadedProperty`. Note that `VerticalAlign`.)
+-}
+type alias BackgroundBlendMode compatible =
+    ColorValue compatible -> Style
 
 
 {-| <https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip>
@@ -1813,98 +1825,98 @@ vertical =
 
 {-| The `multiply` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#multiply).
 -}
-multiply : ColorValue compatible -> Style
+multiply : BackgroundBlendMode compatible
 multiply =
     prop1 "multiply"
 
 
 {-| The `screen` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#screen).
 -}
-screenBlendMode : ColorValue compatible -> Style
+screenBlendMode : BackgroundBlendMode compatible
 screenBlendMode =
     prop1 "screen"
 
 
 {-| The `overlay` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#overlay).
 -}
-overlay : ColorValue compatible -> Style
+overlay : BackgroundBlendMode compatible
 overlay =
     prop1 "overlay"
 
 
 {-| The `darken` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#darken).
 -}
-darken : ColorValue compatible -> Style
+darken : BackgroundBlendMode compatible
 darken =
     prop1 "darken"
 
 
 {-| The `lighten` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#lighten).
 -}
-lighten : ColorValue compatible -> Style
+lighten : BackgroundBlendMode compatible
 lighten =
     prop1 "lighten"
 
 
 {-| The `color-dodge` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#color-dodge).
 -}
-colorDodge : ColorValue compatible -> Style
+colorDodge : BackgroundBlendMode compatible
 colorDodge =
     prop1 "color-dodge"
 
 
 {-| The `color-burn` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#color-burn).
 -}
-colorBurn : ColorValue compatible -> Style
+colorBurn : BackgroundBlendMode compatible
 colorBurn =
     prop1 "color-burn"
 
 
 {-| The `hard-light` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#hard-light).
 -}
-hardLight : ColorValue compatible -> Style
+hardLight : BackgroundBlendMode compatible
 hardLight =
     prop1 "hard-light"
 
 
 {-| The `soft-light` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#soft-light).
 -}
-softLight : ColorValue compatible -> Style
+softLight : BackgroundBlendMode compatible
 softLight =
     prop1 "soft-light"
 
 
 {-| The `difference` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#difference).
 -}
-difference : ColorValue compatible -> Style
+difference : BackgroundBlendMode compatible
 difference =
     prop1 "difference"
 
 
 {-| The `exclusion` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#exclusion).
 -}
-exclusion : ColorValue compatible -> Style
+exclusion : BackgroundBlendMode compatible
 exclusion =
     prop1 "exclusion"
 
 
 {-| The `hue` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#hue).
 -}
-hue : ColorValue compatible -> Style
+hue : BackgroundBlendMode compatible
 hue =
     prop1 "hue"
 
 
 {-| The `saturation` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#saturation).
 -}
-saturation : ColorValue compatible -> Style
+saturation : BackgroundBlendMode compatible
 saturation =
     prop1 "saturation"
 
 
 {-| The `luminosity` [`blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#luminosity).
 -}
-luminosity : ColorValue compatible -> Style
+luminosity : BackgroundBlendMode compatible
 luminosity =
     prop1 "luminosity"
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1465,10 +1465,8 @@ type alias LengthOrAutoOrCoverOrContain compatible =
 type alias Length compatible units =
     Value
         { compatible
-            | length : Compatible
-            , numericValue : Float
-            , units : units
-            , unitLabel : String
+            | units : units
+            , length : Compatible
         }
 
 
@@ -2044,8 +2042,6 @@ type alias BasicProperty =
         , fontWeight : Compatible
         , fontVariant : Compatible
         , units : IncompatibleUnits
-        , numericValue : Float
-        , unitLabel : String
         , backgroundRepeat : Compatible
         , backgroundRepeatShorthand : Compatible
         , backgroundAttachment : Compatible
@@ -2420,11 +2416,6 @@ true =
 {- LENGTHS -}
 
 
-lengthConverter : String -> Float -> ExplicitLength units
-lengthConverter label value =
-    Value (numberToString value ++ label)
-
-
 {-| Convenience length value that compiles to 0 with no units.
 
     css [ padding zero ]
@@ -2445,8 +2436,6 @@ zero :
         , number : Compatible
         , outline : Compatible
         , units : UnitlessInteger
-        , unitLabel : String
-        , numericValue : Float
         , lengthOrAutoOrCoverOrContain : Compatible
         }
 zero =
@@ -2456,211 +2445,163 @@ zero =
 {-| [`pct`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pct) units.
 -}
 type alias Pct =
-    ExplicitLength PercentageUnits
+    ExplicitLength { percentage : Compatible }
 
 
 {-| [`pct`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pct) units.
 -}
 pct : Float -> Pct
-pct =
-    lengthConverter "%"
-
-
-type PercentageUnits
-    = PercentageUnits
+pct value =
+    Value (numberToString value ++ "%")
 
 
 {-| [`em`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#em) units.
 -}
 type alias Em =
-    ExplicitLength EmUnits
+    ExplicitLength { em : Compatible }
 
 
 {-| [`em`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#em) units.
 -}
 em : Float -> Em
-em =
-    lengthConverter "em"
-
-
-type EmUnits
-    = EmUnits
+em value =
+    Value (numberToString value ++ "em")
 
 
 {-| [`ex`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex) units.
 -}
 type alias Ex =
-    ExplicitLength ExUnits
+    ExplicitLength { ex : Compatible }
 
 
 {-| [`ex`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex) units.
 -}
 ex : Float -> Ex
-ex =
-    lengthConverter "ex"
-
-
-type ExUnits
-    = ExUnits
+ex value =
+    Value (numberToString value ++ "ex")
 
 
 {-| [`ch`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ch) units.
 -}
 type alias Ch =
-    ExplicitLength ChUnits
+    ExplicitLength { ch : Compatible }
 
 
 {-| [`ch`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ch) units.
 -}
 ch : Float -> Ch
-ch =
-    lengthConverter "ch"
-
-
-type ChUnits
-    = ChUnits
+ch value =
+    Value (numberToString value ++ "ch")
 
 
 {-| [`rem`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem) units.
 -}
 type alias Rem =
-    ExplicitLength RemUnits
+    ExplicitLength { rem : Compatible }
 
 
 {-| [`rem`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem) units.
 -}
 rem : Float -> Rem
-rem =
-    lengthConverter "rem"
-
-
-type RemUnits
-    = RemUnits
+rem value =
+    Value (numberToString value ++ "rem")
 
 
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
 -}
 type alias Vh =
-    ExplicitLength VhUnits
+    ExplicitLength { vk : Compatible }
 
 
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
 -}
 vh : Float -> Vh
-vh =
-    lengthConverter "vh"
-
-
-type VhUnits
-    = VhUnits
+vh value =
+    Value (numberToString value ++ "vh")
 
 
 {-| [`vw`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw) units.
 -}
 type alias Vw =
-    ExplicitLength VwUnits
+    ExplicitLength { vw : Compatible }
 
 
 {-| [`vw`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw) units.
 -}
 vw : Float -> Vw
-vw =
-    lengthConverter "vw"
-
-
-type VwUnits
-    = VwUnits
+vw value =
+    Value (numberToString value ++ "vw")
 
 
 {-| [`vmin`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmin) units.
 -}
 type alias Vmin =
-    ExplicitLength VMinUnits
+    ExplicitLength { vmin : Compatible }
 
 
 {-| [`vmin`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmin) units.
 -}
 vmin : Float -> Vmin
-vmin =
-    lengthConverter "vmin"
-
-
-type VMinUnits
-    = VMinUnits
+vmin value =
+    Value (numberToString value ++ "vmin")
 
 
 {-| [`vmax`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmax) units.
 -}
 type alias Vmax =
-    ExplicitLength VMaxUnits
+    ExplicitLength { vmax : Compatible }
 
 
 {-| [`vmax`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmax) units.
 -}
 vmax : Float -> Vmax
-vmax =
-    lengthConverter "vmax"
-
-
-type VMaxUnits
-    = VMaxUnits
+vmax value =
+    Value (numberToString value ++ "vmax")
 
 
 {-| [`px`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#px) units.
 -}
 type alias Px =
-    ExplicitLength PxUnits
+    ExplicitLength { px : Compatible }
 
 
 {-| [`px`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#px) units.
 -}
 px : Float -> Px
-px =
-    lengthConverter "px"
-
-
-type PxUnits
-    = PxUnits
+px value =
+    Value (numberToString value ++ "px")
 
 
 {-| [``](<https://developer.mozilla.org/en-US/docs/Web/CSS/length#mm>) units.
 -}
 type alias Mm =
-    ExplicitLength MMUnits
+    ExplicitLength { mm : Compatible }
 
 
 {-| [``](<https://developer.mozilla.org/en-US/docs/Web/CSS/length#mm>) units.
 -}
 mm : Float -> Mm
-mm =
-    lengthConverter "mm"
-
-
-type MMUnits
-    = MMUnits
+mm value =
+    Value (numberToString value ++ "mm")
 
 
 {-| [`cm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cm) units.
 -}
 type alias Cm =
-    ExplicitLength CMUnits
+    ExplicitLength { cm : Compatible }
 
 
 {-| [`cm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cm) units.
 -}
 cm : Float -> Cm
-cm =
-    lengthConverter "cm"
-
-
-type CMUnits
-    = CMUnits
+cm value =
+    Value (numberToString value ++ "cm")
 
 
 {-| [`in`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#in) units.
 -}
 type alias In =
-    ExplicitLength InchUnits
+    ExplicitLength { inches : Compatible }
 
 
 {-| [`in`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#in) units.
@@ -2669,80 +2610,68 @@ type alias In =
 
 -}
 inches : Float -> In
-inches =
-    lengthConverter "in"
-
-
-type InchUnits
-    = InchUnits
+inches value =
+    Value (numberToString value ++ "in")
 
 
 {-| [`pt`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pt) units.
 -}
 type alias Pt =
-    ExplicitLength PtUnits
+    ExplicitLength { pt : Compatible }
 
 
 {-| [`pt`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pt) units.
 -}
 pt : Float -> Pt
-pt =
-    lengthConverter "pt"
-
-
-type PtUnits
-    = PtUnits
+pt value =
+    Value (numberToString value ++ "pt")
 
 
 {-| [`pc`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pc) units.
 -}
 type alias Pc =
-    ExplicitLength PcUnits
+    ExplicitLength { pc : Compatible }
 
 
 {-| [`pc`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pc) units.
 -}
 pc : Float -> Pc
-pc =
-    lengthConverter "pc"
-
-
-type PcUnits
-    = PcUnits
+pc value =
+    Value (numberToString value ++ "pc")
 
 
 {-| A unitless integer. Useful with properties like [`borderImageOutset`](#borderImageOutset)
 which accept either length units or unitless numbers for some properties.
 -}
-int : Int -> IntOrAuto (LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (FontWeight (Number { numericValue : Float, unitLabel : String, units : UnitlessInteger }))))
+int : Int -> IntOrAuto (LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (FontWeight (Number { units : UnitlessInteger }))))
 int val =
     Value (numberToString val)
 
 
-type UnitlessInteger
-    = UnitlessInteger
+type alias UnitlessInteger =
+    { integer : Compatible }
 
 
 {-| A unitless number. Useful with properties like [`flexGrow`](#flexGrow)
 which accept unitless numbers.
 -}
-num : Float -> LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (Number { numericValue : Float, unitLabel : String, units : UnitlessFloat }))
+num : Float -> LengthOrNumberOrAutoOrNoneOrContent (LengthOrNumber (Number { units : UnitlessFloat }))
 num val =
     Value (numberToString val)
 
 
-type UnitlessFloat
-    = UnitlessFloat
+type alias UnitlessFloat =
+    { float : Compatible }
 
 
 lengthForOverloadedProperty : ExplicitLength IncompatibleUnits
 lengthForOverloadedProperty =
-    lengthConverter "" 0
+    Value (numberToString 0)
 
 
 {-| -}
-type IncompatibleUnits
-    = IncompatibleUnits
+type alias IncompatibleUnits =
+    { incompatible : Compatible }
 
 
 

--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -1,27 +1,11 @@
 module Css.Media
     exposing
         ( Bits
-        , CanHover
-        , Coarse
-        , Enabled
         , Expression
-        , Fast
-        , Fine
-        , InitialOnly
-        , Interlace
-        , Landscape
         , MediaQuery
         , MediaType
-        , OptionalPaged
-        , P3
-        , Paged
-        , Portrait
-        , Progressive
         , Ratio
-        , Rec2020
         , Resolution
-        , SRGB
-        , Slow
         , all
         , anyHover
         , anyPointer
@@ -112,34 +96,34 @@ module Css.Media
 # Viewport, Page Dimensions Media Features
 
 @docs minWidth, width, maxWidth, minHeight, height, maxHeight, Ratio, ratio
-@docs minAspectRatio, aspectRatio, maxAspectRatio, Landscape, Portrait
+@docs minAspectRatio, aspectRatio, maxAspectRatio
 @docs landscape, portrait, orientation
 
 
 # Display Quality Media Features
 
 @docs Resolution, dpi, dpcm, dppx, minResolution, resolution, maxResolution
-@docs scan, Progressive, Interlace, progressive, interlace, scan, grid, Slow
-@docs Fast, slow, fast, update, Paged, OptionalPaged, paged, optionalPaged
+@docs scan, progressive, interlace, scan, grid
+@docs slow, fast, update, paged, optionalPaged
 @docs overflowBlock, overflowInline
 
 
 # Color Media Features
 
 @docs Bits, bits, minColor, color, maxColor, minMonochrome, monochrome
-@docs maxMonochrome, minColorIndex, colorIndex, maxColorIndex, SRGB, P3
-@docs Rec2020, srgb, p3, rec2020, colorGamut
+@docs maxMonochrome, minColorIndex, colorIndex, maxColorIndex
+@docs srgb, p3, rec2020, colorGamut
 
 
 # Interaction Media Features
 
-@docs Fine, Coarse, fine, coarse, pointer, anyPointer, CanHover, canHover
+@docs fine, coarse, pointer, anyPointer, canHover
 @docs hover, anyHover
 
 
 # Scripting Media Features
 
-@docs InitialOnly, Enabled, initialOnly, enabled, scripting
+@docs initialOnly, enabled, scripting
 
 -}
 
@@ -195,10 +179,6 @@ In the media query `screen and (min-width: 768px)`,
 -}
 type alias Expression =
     Structure.MediaExpression
-
-
-type alias Value compatible =
-    { compatible | value : String }
 
 
 
@@ -364,7 +344,7 @@ speech =
 (percent, vh, vw, and so on), such as px, pt, cm, em, rem, and so on.
 -}
 type alias AbsoluteLength compatible =
-    { compatible | value : String, absoluteLength : Compatible }
+    Value { compatible | absoluteLength : Compatible }
 
 
 {-| Media feature [`min-width`](https://drafts.csswg.org/mediaqueries/#width)
@@ -374,8 +354,8 @@ Queries the width of the output device.
 
 -}
 minWidth : AbsoluteLength compatible -> Expression
-minWidth value =
-    feature "min-width" value
+minWidth =
+    feature "min-width"
 
 
 {-| Media feature [`width`](https://drafts.csswg.org/mediaqueries/#width)
@@ -384,8 +364,8 @@ minWidth value =
 
 -}
 width : AbsoluteLength compatible -> Expression
-width value =
-    feature "width" value
+width =
+    feature "width"
 
 
 {-| Media feature [`max-width`](https://drafts.csswg.org/mediaqueries/#width)
@@ -394,8 +374,8 @@ width value =
 
 -}
 maxWidth : AbsoluteLength compatible -> Expression
-maxWidth value =
-    feature "max-width" value
+maxWidth =
+    feature "max-width"
 
 
 {-| Media feature [`min-height`](https://drafts.csswg.org/mediaqueries/#height)
@@ -404,15 +384,15 @@ maxWidth value =
 
 -}
 minHeight : AbsoluteLength compatible -> Expression
-minHeight value =
-    feature "min-height" value
+minHeight =
+    feature "min-height"
 
 
 {-| Media feature [`height`](https://drafts.csswg.org/mediaqueries/#height)
 -}
 height : AbsoluteLength compatible -> Expression
-height value =
-    feature "height" value
+height =
+    feature "height"
 
 
 {-| Media feature [`max-height`](https://drafts.csswg.org/mediaqueries/#height)
@@ -421,13 +401,13 @@ height value =
 
 -}
 maxHeight : AbsoluteLength compatible -> Expression
-maxHeight value =
-    feature "max-height" value
+maxHeight =
+    feature "max-height"
 
 
 {-| -}
 type alias Ratio =
-    { value : String, ratio : Compatible }
+    Value { ratio : Compatible }
 
 
 {-| Create a ratio.
@@ -438,7 +418,7 @@ type alias Ratio =
 -}
 ratio : Int -> Int -> Ratio
 ratio numerator denominator =
-    { value = toString numerator ++ "/" ++ toString denominator, ratio = Compatible }
+    Value (toString numerator ++ "/" ++ toString denominator)
 
 
 {-| Media feature [`min-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
@@ -447,8 +427,8 @@ ratio numerator denominator =
 
 -}
 minAspectRatio : Ratio -> Expression
-minAspectRatio value =
-    feature "min-aspect-ratio" value
+minAspectRatio =
+    feature "min-aspect-ratio"
 
 
 {-| Media feature [`aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
@@ -457,8 +437,8 @@ minAspectRatio value =
 
 -}
 aspectRatio : Ratio -> Expression
-aspectRatio value =
-    feature "aspect-ratio" value
+aspectRatio =
+    feature "aspect-ratio"
 
 
 {-| Media feature [`max-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
@@ -467,44 +447,34 @@ aspectRatio value =
 
 -}
 maxAspectRatio : Ratio -> Expression
-maxAspectRatio value =
-    feature "max-aspect-ratio" value
+maxAspectRatio =
+    feature "max-aspect-ratio"
 
 
-type alias Orientation a =
-    { a | value : String, orientation : Compatible }
-
-
-{-| -}
-type alias Landscape =
-    { value : String, orientation : Compatible }
-
-
-{-| -}
-type alias Portrait =
-    { value : String, orientation : Compatible }
+type alias Orientation compatible =
+    Value { compatible | orientation : Compatible }
 
 
 {-| CSS value [`landscape`](https://drafts.csswg.org/mediaqueries/#valdef-media-orientation-portrait)
 -}
-landscape : Landscape
+landscape : Orientation {}
 landscape =
-    { value = "landscape", orientation = Compatible }
+    Value "landscape"
 
 
 {-| CSS value [`portrait`](https://drafts.csswg.org/mediaqueries/#valdef-media-orientation-portrait)
 -}
-portrait : Portrait
+portrait : Orientation {}
 portrait =
-    { value = "portrait", orientation = Compatible }
+    Value "portrait"
 
 
 {-| Media feature [`orientation`](https://drafts.csswg.org/mediaqueries/#orientation).
 Accepts `portrait` or `landscape`.
 -}
-orientation : Orientation a -> Expression
-orientation value =
-    feature "orientation" value
+orientation : Orientation compatible -> Expression
+orientation =
+    feature "orientation"
 
 
 
@@ -513,8 +483,8 @@ orientation value =
 
 {-| Display Resolution. <https://www.w3.org/TR/css3-values/#resolution-value>
 -}
-type alias Resolution =
-    { value : String, resolution : Compatible }
+type alias Resolution compatible =
+    Value { compatible | resolution : Compatible }
 
 
 {-| `dpi`: Dots per inch. <https://www.w3.org/TR/css3-values/#resolution-value>
@@ -522,9 +492,9 @@ type alias Resolution =
     dpi 166
 
 -}
-dpi : Float -> Resolution
+dpi : Float -> Resolution {}
 dpi value =
-    { value = toString value ++ "dpi", resolution = Compatible }
+    Value (toString value ++ "dpi")
 
 
 {-| `dpcm`: Dots per centimeter. <https://www.w3.org/TR/css3-values/#resolution-value>
@@ -532,9 +502,9 @@ dpi value =
     dpcm 65
 
 -}
-dpcm : Float -> Resolution
+dpcm : Float -> Resolution {}
 dpcm value =
-    { value = toString value ++ "dpcm", resolution = Compatible }
+    Value (toString value ++ "dpcm")
 
 
 {-| `dppx`: Dots per pixel. <https://www.w3.org/TR/css3-values/#resolution-value>
@@ -542,9 +512,9 @@ dpcm value =
     dppx 1.5
 
 -}
-dppx : Float -> Resolution
+dppx : Float -> Resolution {}
 dppx value =
-    { value = toString value ++ "dppx", resolution = Compatible }
+    Value (toString value ++ "dppx")
 
 
 {-| Media feature [`min-resolution`](https://drafts.csswg.org/mediaqueries/#resolution).
@@ -553,9 +523,9 @@ Describes the resolution of the output device.
     media (minResolution (dpi 600)) [ Css.class HiResImg [ display block ] ]
 
 -}
-minResolution : Resolution -> Expression
-minResolution value =
-    feature "min-resolution" value
+minResolution : Resolution compatible -> Expression
+minResolution =
+    feature "min-resolution"
 
 
 {-| Media feature [`resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
@@ -564,9 +534,9 @@ Describes the resolution of the output device.
     media (resolution (dppx 2)) [ img [ width (pct 50) ] ]
 
 -}
-resolution : Resolution -> Expression
-resolution value =
-    feature "resolution" value
+resolution : Resolution compatible -> Expression
+resolution =
+    feature "resolution"
 
 
 {-| Media feature [`max-resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
@@ -575,45 +545,35 @@ Describes the resolution of the output device.
     media (maxResolution (dpcm 65)) [ Css.class HiResImg [ display none ] ]
 
 -}
-maxResolution : Resolution -> Expression
-maxResolution value =
-    feature "max-resolution" value
+maxResolution : Resolution compatible -> Expression
+maxResolution =
+    feature "max-resolution"
 
 
-type alias ScanningProcess a =
-    { a | value : String, scanningProcess : Compatible }
-
-
-{-| -}
-type alias Progressive =
-    { value : String, scanningProcess : Compatible }
-
-
-{-| -}
-type alias Interlace =
-    { value : String, scanningProcess : Compatible }
+type alias ScanningProcess compatible =
+    Value { compatible | scanningProcess : Compatible }
 
 
 {-| CSS value [`progressive`](https://drafts.csswg.org/mediaqueries/#valdef-media-scan-progressive)
 -}
-progressive : Progressive
+progressive : ScanningProcess {}
 progressive =
-    { value = "progressive", scanningProcess = Compatible }
+    Value "progressive"
 
 
 {-| CSS value [`interlace`](https://drafts.csswg.org/mediaqueries/#valdef-media-scan-interlace)
 -}
-interlace : Interlace
+interlace : ScanningProcess {}
 interlace =
-    { value = "interlace", scanningProcess = Compatible }
+    Value "interlace"
 
 
 {-| Media feature [`scan`](https://drafts.csswg.org/mediaqueries/#scan).
 Queries scanning process of the device. Accepts `innterlace` (some TVs) or `progressive` (most things).
 -}
-scan : ScanningProcess a -> Expression
-scan value =
-    feature "scan" value
+scan : ScanningProcess compatible -> Expression
+scan =
+    feature "scan"
 
 
 {-| Media feature [`grid`](https://drafts.csswg.org/mediaqueries/#grid).
@@ -624,88 +584,68 @@ grid =
     unparameterizedFeature "grid"
 
 
-type alias UpdateFrequency a =
-    { a | value : String, updateFrequency : Compatible }
-
-
-{-| -}
-type alias Slow =
-    { value : String, updateFrequency : Compatible }
-
-
-{-| -}
-type alias Fast =
-    { value : String, updateFrequency : Compatible }
+type alias UpdateFrequency compatible =
+    Value { compatible | updateFrequency : Compatible }
 
 
 {-| CSS value [`slow`](https://drafts.csswg.org/mediaqueries/#valdef-media-update-slow)
 -}
-slow : Slow
+slow : UpdateFrequency {}
 slow =
-    { value = "slow", updateFrequency = Compatible }
+    Value "slow"
 
 
 {-| CSS value [`fast`](https://drafts.csswg.org/mediaqueries/#valdef-media-update-fast)
 -}
-fast : Fast
+fast : UpdateFrequency {}
 fast =
-    { value = "fast", updateFrequency = Compatible }
+    Value "fast"
 
 
 {-| Media feature [`update`](https://drafts.csswg.org/mediaqueries/#update)
 The update frequency of the device. Accepts `none`, `slow`, or `fast`
 -}
-update : UpdateFrequency a -> Expression
-update value =
-    feature "update" value
+update : UpdateFrequency compatible -> Expression
+update =
+    feature "update"
 
 
-type alias BlockAxisOverflow a =
-    { a | value : String, blockAxisOverflow : Compatible }
-
-
-{-| -}
-type alias Paged =
-    { value : String, blockAxisOverflow : Compatible }
-
-
-{-| -}
-type alias OptionalPaged =
-    { value : String, blockAxisOverflow : Compatible }
+type alias BlockAxisOverflow compatible =
+    Value { compatible | blockAxisOverflow : Compatible }
 
 
 {-| CSS value [`paged`](https://drafts.csswg.org/mediaqueries/#valdef-media-overflow-block-paged)
 -}
-paged : Paged
+paged : BlockAxisOverflow {}
 paged =
-    { value = "paged", blockAxisOverflow = Compatible }
+    Value "paged"
 
 
 {-| CSS value [`optional-paged`](https://drafts.csswg.org/mediaqueries/#valdef-media-overflow-block-optional-paged)
 -}
-optionalPaged : OptionalPaged
+optionalPaged : BlockAxisOverflow {}
 optionalPaged =
-    { value = "optional-paged", blockAxisOverflow = Compatible }
+    Value "optional-paged"
 
 
 {-| Media feature [`overflow-block`](https://drafts.csswg.org/mediaqueries/#overflow-block)
 Describes the behavior of the device when content overflows the initial containing block in the block axis.
 -}
-overflowBlock : BlockAxisOverflow a -> Expression
-overflowBlock value =
-    feature "overflow-block" value
+overflowBlock : BlockAxisOverflow compatible -> Expression
+overflowBlock =
+    feature "overflow-block"
 
 
-type alias InlineAxisOverflow a =
-    { a | value : String, inlineAxisOverflow : Compatible }
+type alias InlineAxisOverflow compatible =
+    Value { compatible | inlineAxisOverflow : Compatible }
 
 
 {-| Media feature [`overflow-inline`](https://drafts.csswg.org/mediaqueries/#overflow-inline).
 Describes the behavior of the device when content overflows the initial containing block in the inline axis.
 -}
-overflowInline : InlineAxisOverflow a -> Expression
-overflowInline value =
-    feature "overflow-inline" value
+overflowInline : InlineAxisOverflow compatible -> Expression
+overflowInline =
+    feature "overflow-inline"
 
 
 
@@ -714,7 +654,7 @@ overflowInline value =
 
 {-| -}
 type alias Bits =
-    { value : String, bits : Compatible }
+    Value { bits : Compatible }
 
 
 {-| Get a bumber of bits
@@ -724,7 +664,7 @@ type alias Bits =
 -}
 bits : Int -> Bits
 bits value =
-    { value = toString value, bits = Compatible }
+    Value (toString value)
 
 
 {-| Media Feature [`min-nncolor`](https://drafts.csswg.org/mediaqueries/#color)
@@ -734,8 +674,8 @@ Queries the user agent's bits per color channel
 
 -}
 minColor : Bits -> Expression
-minColor value =
-    feature "min-color" value
+minColor =
+    feature "min-color"
 
 
 {-| Media feature [`color`](https://drafts.csswg.org/mediaqueries/#color)
@@ -755,8 +695,8 @@ Queries the user agent's bits per color channel
 
 -}
 maxColor : Bits -> Expression
-maxColor value =
-    feature "max-color" value
+maxColor =
+    feature "max-color"
 
 
 {-| Media feature [`monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
@@ -772,15 +712,15 @@ monochrome =
 {-| Media Feature [`min-monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
 -}
 minMonochrome : Bits -> Expression
-minMonochrome value =
-    feature "min-monochrome" value
+minMonochrome =
+    feature "min-monochrome"
 
 
 {-| Media feature [`max-monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
 -}
 maxMonochrome : Bits -> Expression
-maxMonochrome value =
-    feature "max-monochrome" value
+maxMonochrome =
+    feature "max-monochrome"
 
 
 {-| Media feature [`color-index`](https://drafts.csswg.org/mediaqueries/#color-index)
@@ -789,9 +729,9 @@ Queries the number of colors in the user agent's color lookup table.
     media (and screen (colorIndex (int 16777216))) [ a [ Css.color (hex "D9534F") ] ]
 
 -}
-colorIndex : Number a -> Expression
-colorIndex value =
-    feature "color-index" value
+colorIndex : Number compatible -> Expression
+colorIndex =
+    feature "color-index"
 
 
 {-| Media Feature [`min-color-index`](https://drafts.csswg.org/mediaqueries/nn#color-index)
@@ -800,9 +740,9 @@ Queries the number of colors in the user agent's color lookup table.
     media (and screen (minColorIndex (int 16777216))) [ a [ Css.color (hex "D9534F")] ]
 
 -}
-minColorIndex : Number a -> Expression
-minColorIndex value =
-    feature "min-color-index" value
+minColorIndex : Number compatible -> Expression
+minColorIndex =
+    feature "min-color-index"
 
 
 {-| Media feature [`max-color-index`](https://drafts.csswg.org/mediaqueries/#color-index).
@@ -811,49 +751,34 @@ Queries the number of colors in the user agent's color lookup table.
     media (and screen (maxColorIndex (int 256))) [ a [ Css.color (hex "FF0000")] ]
 
 -}
-maxColorIndex : Number a -> Expression
-maxColorIndex value =
-    feature "max-color-index" value
+maxColorIndex : Number compatible -> Expression
+maxColorIndex =
+    feature "max-color-index"
 
 
-type alias ColorGamut a =
-    { a | value : String, colorGamut : Compatible }
-
-
-{-| -}
-type alias SRGB =
-    { value : String, colorGamut : Compatible }
-
-
-{-| -}
-type alias P3 =
-    { value : String, colorGamut : Compatible }
-
-
-{-| -}
-type alias Rec2020 =
-    { value : String, colorGamut : Compatible }
+type alias ColorGamut compatible =
+    Value { compatible | colorGamut : Compatible }
 
 
 {-| CSS value [`srgb`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-srgb)
 -}
-srgb : SRGB
+srgb : ColorGamut {}
 srgb =
-    { value = "srgb", colorGamut = Compatible }
+    Value "srgb"
 
 
 {-| CSS value [`p3`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-p3)
 -}
-p3 : P3
+p3 : ColorGamut {}
 p3 =
-    { value = "p3", colorGamut = Compatible }
+    Value "p3"
 
 
 {-| CSS value [`rec2020`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-rec2020)
 -}
-rec2020 : Rec2020
+rec2020 : ColorGamut {}
 rec2020 =
-    { value = "rec2020", colorGamut = Compatible }
+    Value "rec2020"
 
 
 {-| Media feature [`color-gamut`](https://drafts.csswg.org/mediaqueries/#color-gamut).
@@ -862,9 +787,9 @@ Describes the approximate range of colors supported by the user agent and device
     media (and screen (colorGamut rec2020)) [ Css.class HiColorImg [ display block ] ]
 
 -}
-colorGamut : ColorGamut a -> Expression
-colorGamut value =
-    feature "color-gamut" value
+colorGamut : ColorGamut compatible -> Expression
+colorGamut =
+    feature "color-gamut"
 
 
 
@@ -874,32 +799,22 @@ colorGamut value =
 {-| Describes the presence and accuracy of a pointing device such as a mouse
 <https://drafts.csswg.org/mediaqueries/#pointer>
 -}
-type alias PointerDevice a =
-    { a | value : String, pointerDevice : Compatible }
-
-
-{-| -}
-type alias Fine =
-    { value : String, pointerDevice : Compatible }
-
-
-{-| -}
-type alias Coarse =
-    { value : String, pointerDevice : Compatible }
+type alias PointerDevice compatible =
+    Value { compatible | pointerDevice : Compatible }
 
 
 {-| CSS Value [`fine`](https://drafts.csswg.org/mediaqueries/#valdef-media-pointer-fine)
 -}
-fine : Fine
+fine : PointerDevice {}
 fine =
-    { value = "fine", pointerDevice = Compatible }
+    Value "fine"
 
 
 {-| CSS Value [`coarse`](https://drafts.csswg.org/mediaqueries/#valdef-media-pointer-coarse)
 -}
-coarse : Coarse
+coarse : PointerDevice {}
 coarse =
-    { value = "coarse", pointerDevice = Compatible }
+    Value "coarse"
 
 
 {-| Media feature [`pointer`](https://drafts.csswg.org/mediaqueries/#pointer)
@@ -910,9 +825,9 @@ Accepts `none`, `fine`, and `coarse`.
     media (Media.pointer coarse) [ a [ display block, Css.height (px 24) ] ]
 
 -}
-pointer : PointerDevice a -> Expression
-pointer value =
-    feature "pointer" value
+pointer : PointerDevice compatible -> Expression
+pointer =
+    feature "pointer"
 
 
 {-| Media feature [`any-pointer`](https://drafts.csswg.org/mediaqueries/#any-input)
@@ -923,27 +838,22 @@ Accepts `none`, `fine`, and `coarse`.
     media (anyPointer coarse) [ a [ display block, Css.height (px 24) ] ]
 
 -}
-anyPointer : PointerDevice a -> Expression
-anyPointer value =
-    feature "any-pointer" value
+anyPointer : PointerDevice compatible -> Expression
+anyPointer =
+    feature "any-pointer"
 
 
 {-| -}
-type alias HoverCapability a =
-    { a | value : String, hoverCapability : Compatible }
-
-
-{-| -}
-type alias CanHover =
-    { value : String, hoverCapability : Compatible }
+type alias HoverCapability compatible =
+    Value { compatible | hoverCapability : Compatible }
 
 
 {-| The value [`hover`](https://drafts.csswg.org/mediaqueries/#valdef-media-hover-hover).
 Named `canHover` to avoid conflict with the media feature of the same name
 -}
-canHover : CanHover
+canHover : HoverCapability {}
 canHover =
-    { value = "hover", hoverCapability = Compatible }
+    Value "hover"
 
 
 {-| Media feature [`hover`](https://drafts.csswg.org/mediaqueries/#hover).
@@ -953,9 +863,9 @@ Accepts `none` or `canHover`.
     media (Media.hover canHover) [ a [ Css.hover [ textDecoration underline] ] ]
 
 -}
-hover : HoverCapability a -> Expression
-hover value =
-    feature "hover" value
+hover : HoverCapability compatible -> Expression
+hover =
+    feature "hover"
 
 
 {-| Media feature [`any-hover`](https://drafts.csswg.org/mediaqueries/#any-input)
@@ -965,9 +875,9 @@ Accepts `none` or `canHover`.
     media (anyHover canHover) [ a [ Css.hover [ textDecoration underline] ] ]
 
 -}
-anyHover : HoverCapability a -> Expression
-anyHover value =
-    feature "any-hover" value
+anyHover : HoverCapability compatible -> Expression
+anyHover =
+    feature "any-hover"
 
 
 
@@ -975,32 +885,22 @@ anyHover value =
 
 
 {-| -}
-type alias ScriptingSupport a =
-    { a | value : String, scriptingSupport : Compatible }
-
-
-{-| -}
-type alias InitialOnly =
-    { value : String, scriptingSupport : Compatible }
-
-
-{-| -}
-type alias Enabled =
-    { value : String, scriptingSupport : Compatible }
+type alias ScriptingSupport compatible =
+    Value { compatible | scriptingSupport : Compatible }
 
 
 {-| CSS value [`initial-only`](https://drafts.csswg.org/mediaqueries/#valdef-media-scripting-initial-only).
 -}
-initialOnly : InitialOnly
+initialOnly : ScriptingSupport {}
 initialOnly =
-    { value = "initial-only", scriptingSupport = Compatible }
+    Value "initial-only"
 
 
 {-| CSS value [`enabled`](https://drafts.csswg.org/mediaqueries/#valdef-media-scripting-enabled).
 -}
-enabled : Enabled
+enabled : ScriptingSupport {}
 enabled =
-    { value = "enabled", scriptingSupport = Compatible }
+    Value "enabled"
 
 
 {-| The [`scripting`](https://drafts.csswg.org/mediaqueries/#scripting) media feature
@@ -1010,9 +910,9 @@ Accepts `none`, `initialOnly`, and `enabled`.
     media (scripting none) [ Css.class NoScript [ display block ] ]
 
 -}
-scripting : ScriptingSupport a -> Expression
-scripting value =
-    feature "scripting" value
+scripting : ScriptingSupport compatible -> Expression
+scripting =
+    feature "scripting"
 
 
 
@@ -1020,7 +920,7 @@ scripting value =
 
 
 feature : String -> Value a -> Expression
-feature key { value } =
+feature key (Value value) =
     { feature = key, value = Just value }
 
 

--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -1,11 +1,21 @@
 module Css.Media
     exposing
-        ( Bits
+        ( AbsoluteLength
+        , Bits
+        , BlockAxisOverflow
+        , ColorGamut
         , Expression
+        , HoverCapability
+        , InlineAxisOverflow
         , MediaQuery
         , MediaType
+        , Orientation
+        , PointerDevice
         , Ratio
         , Resolution
+        , ScanningProcess
+        , ScriptingSupport
+        , UpdateFrequency
         , all
         , anyHover
         , anyPointer
@@ -95,35 +105,35 @@ module Css.Media
 
 # Viewport, Page Dimensions Media Features
 
-@docs minWidth, width, maxWidth, minHeight, height, maxHeight, Ratio, ratio
-@docs minAspectRatio, aspectRatio, maxAspectRatio
-@docs landscape, portrait, orientation
+@docs AbsoluteLength, minWidth, width, maxWidth, minHeight, height, maxHeight
+@docs Ratio, ratio, maxAspectRatio, minAspectRatio, aspectRatio
+@docs Orientation, landscape, portrait, orientation
 
 
 # Display Quality Media Features
 
 @docs Resolution, dpi, dpcm, dppx, minResolution, resolution, maxResolution
-@docs scan, progressive, interlace, scan, grid
-@docs slow, fast, update, paged, optionalPaged
-@docs overflowBlock, overflowInline
+@docs ScanningProcess, scan, progressive, interlace, scan, grid
+@docs UpdateFrequency, slow, fast, update, paged, optionalPaged
+@docs BlockAxisOverflow, InlineAxisOverflow, overflowBlock, overflowInline
 
 
 # Color Media Features
 
 @docs Bits, bits, minColor, color, maxColor, minMonochrome, monochrome
-@docs maxMonochrome, minColorIndex, colorIndex, maxColorIndex
-@docs srgb, p3, rec2020, colorGamut
+@docs maxColorIndex, maxMonochrome, minColorIndex, colorIndex
+@docs ColorGamut, srgb, p3, rec2020, colorGamut
 
 
 # Interaction Media Features
 
-@docs fine, coarse, pointer, anyPointer, canHover
-@docs hover, anyHover
+@docs PointerDevice, fine, coarse, pointer, anyPointer, canHover
+@docs HoverCapability, hover, anyHover
 
 
 # Scripting Media Features
 
-@docs initialOnly, enabled, scripting
+@docs ScriptingSupport, initialOnly, enabled, scripting
 
 -}
 
@@ -451,6 +461,7 @@ maxAspectRatio =
     feature "max-aspect-ratio"
 
 
+{-| -}
 type alias Orientation compatible =
     Value { compatible | orientation : Compatible }
 
@@ -550,6 +561,7 @@ maxResolution =
     feature "max-resolution"
 
 
+{-| -}
 type alias ScanningProcess compatible =
     Value { compatible | scanningProcess : Compatible }
 
@@ -584,6 +596,7 @@ grid =
     unparameterizedFeature "grid"
 
 
+{-| -}
 type alias UpdateFrequency compatible =
     Value { compatible | updateFrequency : Compatible }
 
@@ -610,6 +623,7 @@ update =
     feature "update"
 
 
+{-| -}
 type alias BlockAxisOverflow compatible =
     Value { compatible | blockAxisOverflow : Compatible }
 
@@ -636,6 +650,7 @@ overflowBlock =
     feature "overflow-block"
 
 
+{-| -}
 type alias InlineAxisOverflow compatible =
     Value { compatible | inlineAxisOverflow : Compatible }
 
@@ -756,6 +771,7 @@ maxColorIndex =
     feature "max-color-index"
 
 
+{-| -}
 type alias ColorGamut compatible =
     Value { compatible | colorGamut : Compatible }
 

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -9,11 +9,16 @@ elm-css DSL, collecting warnings, or
 {-| For typing
 -}
 type Compatible
-    = Compatible
+    = Compatible Never
+
+
+{-| -}
+type Value compatible
+    = Value String
 
 
 type alias Number compatible =
-    { compatible | value : String, number : Compatible }
+    Value { compatible | number : Compatible }
 
 
 {-| A property consisting of a key:value string.

--- a/tests/Colors.elm
+++ b/tests/Colors.elm
@@ -1,51 +1,27 @@
-module Colors exposing (..)
+module Colors exposing (hexTests)
 
-import Css exposing (..)
+import Css exposing (hex)
 import Expect
-import Test exposing (..)
+import Test exposing (Test, describe, test)
 
 
 hexTests : Test
 hexTests =
     describe "hex color mixing"
-        [ test "fff works" <|
+        [ test "short hashless color" <|
             \() ->
                 hex "fff"
                     |> Expect.equal (hex "#fff")
-        , test "#fff works" <|
+        , test "long hashless color" <|
             \() ->
-                hex "#fff"
-                    |> Expect.equal (hex "#fff")
-        , test "000 works" <|
-            \() ->
-                hex "000"
-                    |> Expect.equal (hex "#000")
-        , test "#0f0 works" <|
-            \() ->
-                hex "#0f0"
-                    |> Expect.equal (hex "#0f0")
-        , test "#00f works" <|
-            \() ->
-                hex "#00f"
-                    |> Expect.equal (hex "#00f")
-        , test "#f00 works" <|
-            \() ->
-                hex "#f00"
-                    |> Expect.equal (hex "#f00")
-        , test "#000 works" <|
+                hex "0ff000"
+                    |> Expect.equal (hex "#0ff000")
+        , test "short hash color" <|
             \() ->
                 hex "#000"
                     |> Expect.equal (hex "#000")
-        , test "#0000 works" <|
+        , test "long hash color" <|
             \() ->
-                hex "#0000"
-                    |> Expect.equal (hex "#0000")
-        , test "#000f works" <|
-            \() ->
-                hex "#000f"
-                    |> Expect.equal (hex "#000f")
-        , test "#012345678 works" <|
-            \() ->
-                hex "#012345678"
-                    |> Expect.equal (hex "#012345678")
+                hex "#f00fff"
+                    |> Expect.equal (hex "#f00fff")
         ]

--- a/tests/Colors.elm
+++ b/tests/Colors.elm
@@ -1,9 +1,7 @@
 module Colors exposing (..)
 
 import Css exposing (..)
-import Expect exposing (Expectation)
-import Fuzz exposing (Fuzzer)
-import Hex
+import Expect
 import Test exposing (..)
 
 
@@ -13,71 +11,41 @@ hexTests =
         [ test "fff works" <|
             \() ->
                 hex "fff"
-                    |> expectEqualsRgba ( 255, 255, 255, 1 )
+                    |> Expect.equal (hex "#fff")
         , test "#fff works" <|
             \() ->
                 hex "#fff"
-                    |> expectEqualsRgba ( 255, 255, 255, 1 )
+                    |> Expect.equal (hex "#fff")
         , test "000 works" <|
             \() ->
                 hex "000"
-                    |> expectEqualsRgba ( 0, 0, 0, 1 )
+                    |> Expect.equal (hex "#000")
         , test "#0f0 works" <|
             \() ->
                 hex "#0f0"
-                    |> expectEqualsRgba ( 0, 255, 0, 1 )
+                    |> Expect.equal (hex "#0f0")
         , test "#00f works" <|
             \() ->
                 hex "#00f"
-                    |> expectEqualsRgba ( 0, 0, 255, 1 )
+                    |> Expect.equal (hex "#00f")
         , test "#f00 works" <|
             \() ->
                 hex "#f00"
-                    |> expectEqualsRgba ( 255, 0, 0, 1 )
+                    |> Expect.equal (hex "#f00")
         , test "#000 works" <|
             \() ->
                 hex "#000"
-                    |> expectEqualsRgba ( 0, 0, 0, 1 )
-        , fuzz (Fuzz.tuple4 ( hexInt, hexInt, hexInt, hexInt )) "a valid 8-char hex string" <|
-            \tuple ->
-                tuple
-                    |> fromRgba8
-                    |> hex
-                    |> expectEqualsRgba (alphaToPercentage tuple)
+                    |> Expect.equal (hex "#000")
+        , test "#0000 works" <|
+            \() ->
+                hex "#0000"
+                    |> Expect.equal (hex "#0000")
+        , test "#000f works" <|
+            \() ->
+                hex "#000f"
+                    |> Expect.equal (hex "#000f")
+        , test "#012345678 works" <|
+            \() ->
+                hex "#012345678"
+                    |> Expect.equal (hex "#012345678")
         ]
-
-
-alphaToPercentage : ( Int, Int, Int, Int ) -> ( Int, Int, Int, Float )
-alphaToPercentage ( r, g, b, a ) =
-    ( r, g, b, toFloat a / 255 )
-
-
-fromRgba8 : ( Int, Int, Int, Int ) -> String
-fromRgba8 ( r, g, b, a ) =
-    [ r, g, b, a ]
-        |> List.map (Hex.toString >> String.padLeft 2 '0')
-        |> String.join ""
-
-
-smallHexInt : Fuzzer Int
-smallHexInt =
-    Fuzz.intRange 0 15
-
-
-hexInt : Fuzzer Int
-hexInt =
-    Fuzz.intRange 0 255
-
-
-expectEqualsRgba :
-    ( Int, Int, Int, Float )
-    -> { record | red : Int, green : Int, blue : Int, alpha : Float }
-    -> Expectation
-expectEqualsRgba ( expectedRed, expectedGreen, expectedBlue, expectedAlpha ) { red, green, blue, alpha } =
-    { red = red, green = green, blue = blue, alpha = alpha }
-        |> Expect.equal
-            { red = expectedRed
-            , green = expectedGreen
-            , blue = expectedBlue
-            , alpha = expectedAlpha
-            }

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -337,7 +337,7 @@ fontStylesheet =
             , fontFamilies
                 [ qt "Gill Sans Extrabold"
                 , "Helvetica"
-                , .value sansSerif
+                , "sans-serif"
                 ]
             , fontSize xSmall
             , fontStyle italic


### PR DESCRIPTION
Hello, first of al thanks for the package - it's a really huge work.

## Problem 1: access to not exposed `Compatible`

When I was testing this package first time I realised that developers able to use some values like this:

```elm
myCustomColor: Css.ColorValue {}
myCustomColor =
	{ value = "some invalid color", color = Css.transparent.value }
```

I think it's unexpected using of the package and something has to change the situation.

## Problem 2: huge value records

Each value of css rule is described as type alias with dynamic record with `Compatible`. It means that result record should contain same structure as type alias:

```elm
auto :
    { value : String
    , lengthOrAuto : Compatible
    , overflow : Compatible
    , textRendering : Compatible
    , flexBasis : Compatible
    , lengthOrNumberOrAutoOrNoneOrContent : Compatible
    , alignItemsOrAuto : Compatible
    , justifyContentOrAuto : Compatible
    , cursor : Compatible
    , lengthOrAutoOrCoverOrContain : Compatible
    , intOrAuto : Compatible
    , pointerEvents : Compatible
    , touchAction : Compatible
    , tableLayout : Compatible
    }
auto =
    { value = "auto"
    , lengthOrAuto = Compatible
    , overflow = Compatible
    , textRendering = Compatible
    , flexBasis = Compatible
    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
    , alignItemsOrAuto = Compatible
    , justifyContentOrAuto = Compatible
    , cursor = Compatible
    , lengthOrAutoOrCoverOrContain = Compatible
    , intOrAuto = Compatible
    , pointerEvents = Compatible
    , touchAction = Compatible
    , tableLayout = Compatible
    }
```

It looks little bit redundantly.

## Decision

We can solve both problems by one decision:

```elm
type Value compatible
    = Value String
```

Only the `Value` type should be exposed and as result we will get something like this:

```elm
auto :
    Value
        { lengthOrAuto : Compatible
        , overflow : Compatible
        , textRendering : Compatible
        , flexBasis : Compatible
        , lengthOrNumberOrAutoOrNoneOrContent : Compatible
        , alignItemsOrAuto : Compatible
        , justifyContentOrAuto : Compatible
        , cursor : Compatible
        , lengthOrAutoOrCoverOrContain : Compatible
        , intOrAuto : Compatible
        , pointerEvents : Compatible
        , touchAction : Compatible
        , tableLayout : Compatible
        }
auto =
    Value "auto"
```

## Advantages

1. Developers don't have access to `Compatible` by getting value of record field so they can't create custom css values without using API of `Css`
2. Value records is gone and each css value should be described as `Value String`. 
3. Type guard still works.

## Disadvantages

1. Specific fields cannot be passed by record because it works only for type checking (`numericValue` and `unitLabel`)
	```elm
	type alias Length compatible units =
	    { compatible
	        | value : String
	        , length : Compatible
	        , numericValue : Float
	        , units : units
	        , unitLabel : String
	    }
	```
	But I'm not sure that this point is bad because we should do it in fact.
2. Types of css values cannot be nested:
	```elm
	content : LengthOrNumberOrAutoOrNoneOrContent (FlexBasis {})
	content =
	    { value = "content"
	    , flexBasis = Compatible
	    , lengthOrNumberOrAutoOrNoneOrContent = Compatible
	    }
	```

## Conclusion

There are a lot of changes but most of them looks like changing of records to `Value String`. Some exposed types has been removed/added and that will increase package version. I don't familiar with your politic of version management and hope that it won't be a big deal. There are big changes of working with colours (it was simplified in general).